### PR TITLE
allow precomputed tree

### DIFF
--- a/src/gpytoolbox/ray_mesh_intersect.py
+++ b/src/gpytoolbox/ray_mesh_intersect.py
@@ -68,6 +68,8 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
         Matrix of AABB box centers (if None and use_embree=False, will be computed)
     W : numpy double array, optional (default None)
         Matrix of AABB box widths (if None and use_embree=False, will be computed)
+    CH : numpy int array, optional (default None)
+        Matrix of child indeces (-1 if leaf node). If None and use_embree=False, will be computed
     tri_indices : numpy int array, optional (default None)
         Vector of AABB element indices (-1 if *not* leaf node). If None and use_embree=False, will be computed
 

--- a/src/gpytoolbox/ray_mesh_intersect.py
+++ b/src/gpytoolbox/ray_mesh_intersect.py
@@ -47,7 +47,7 @@ class ray_mesh_intersect_traversal:
 
 
 
-def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True):
+def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None,tri_ind=None):
     """Shoot a ray from a position and see where it crashes into a given mesh
 
     Uses a bounding volume hierarchy to efficiently compute intersections of many different rays with a given mesh.
@@ -64,6 +64,12 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True):
         face index list of a triangle mesh
     use_embree : bool, optional (default True)
         Whether to use the much more optimzed C++ AABB embree implementation of ray mesh intersections. If False, uses gpytoolbox's native AABB tree and gpytoolbox's intersection queries.
+    C : numpy double array, optional (default None)
+        Matrix of AABB box centers (if None and use_embree=False, will be computed)
+    W : numpy double array, optional (default None)
+        Matrix of AABB box widths (if None and use_embree=False, will be computed)
+    tri_indices : numpy int array, optional (default None)
+        Vector of AABB element indices (-1 if *not* leaf node). If None and use_embree=False, will be computed
 
     Returns
     -------
@@ -96,7 +102,8 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True):
         ids = -np.ones(cam_pos.shape[0],dtype=int)
         lambdas = np.zeros((cam_pos.shape[0],3))
         # print("building tree")
-        C,W,CH,PAR,D,tri_ind = initialize_aabbtree(V,F=F)
+        if ((C is None) or (W is None) or (tri_ind is None) or (CH is None)):
+            C,W,CH,_,_,tri_ind = initialize_aabbtree(V,F=F)
         # print("built tree")
         # print("computing distances")
         for i in range(cam_pos.shape[0]):

--- a/src/gpytoolbox/squared_distance.py
+++ b/src/gpytoolbox/squared_distance.py
@@ -50,7 +50,7 @@ class closest_point_traversal:
 
 
 
-def squared_distance(P,V,F=None,use_aabb=False):
+def squared_distance(P,V,F=None,use_aabb=False,C=None,W=None,CH=None,tri_ind=None):
     """Squared distances from a set of points in space.
 
     General-purpose function which computes the squared distance from a set of points to a mesh, point cloud or polyline, in two or three dimensions. Optionally, uses an aabb tree for efficient computation.
@@ -74,6 +74,14 @@ def squared_distance(P,V,F=None,use_aabb=False):
         Indices into F (or V, if F is None) of closest elements to each query point
     lmbs : (p,s) numpy double array
         Barycentric coordinates into the closest element of each closest mesh point to each query point
+    C : numpy double array, optional (default None)
+        Matrix of AABB box centers (if None, will be computed)
+    W : numpy double array, optional (default None)
+        Matrix of AABB box widths (if None, will be computed)
+    CH : numpy int array, optional (default None)
+        Matrix of child indeces (-1 if leaf node). If None, will be computed
+    tri_indices : numpy int array, optional (default None)
+        Vector of AABB element indices (-1 if *not* leaf node). If None, will be computed
 
     See Also
     --------
@@ -100,7 +108,8 @@ def squared_distance(P,V,F=None,use_aabb=False):
     lmbs = np.zeros((P.shape[0],F.shape[1]))
     if use_aabb:
         # Build tree once
-        C,W,CH,PAR,D,tri_ind = initialize_aabbtree(V,F=F)
+        if ((C is None) or (W is None) or (tri_ind is None) or (CH is None)):
+            C,W,CH,_,_,tri_ind = initialize_aabbtree(V,F=F)
         for j in range(P.shape[0]):
             t = closest_point_traversal(V,F,P[j,:])
             traverse_fun = t.traversal_function

--- a/test/test_ray_mesh_intersect.py
+++ b/test/test_ray_mesh_intersect.py
@@ -56,6 +56,14 @@ class TestRayMeshIntersect(unittest.TestCase):
             self.assertTrue(np.isclose(te-t,0,atol=1e-4).all())
             self.assertTrue(np.isclose(ids-idse,0,atol=1e-4).all())
             self.assertTrue(np.isclose(l-le,0,atol=1e-4).all())
+            # Now precomputing tree:
+            C,W,CH,_,_,tri_ind = gpytoolbox.initialize_aabbtree(v,F=f)
+            t, ids, l = gpytoolbox.ray_mesh_intersect(cam_pos,-cam_pos,v,f,use_embree=False,C=C,CH=CH,W=W,tri_ind=tri_ind)
+            self.assertTrue(np.isclose(te-t,0,atol=1e-4).all())
+            self.assertTrue(np.isclose(ids-idse,0,atol=1e-4).all())
+            self.assertTrue(np.isclose(l-le,0,atol=1e-4).all())
+
+
 
 
 if __name__ == '__main__':

--- a/test/test_squared_distance.py
+++ b/test/test_squared_distance.py
@@ -150,6 +150,17 @@ class TestSquaredDistance(unittest.TestCase):
             self.assertTrue(np.isclose(sqrD_aabb-sqrD_gt,0).all())
             self.assertTrue(np.isclose(inter_points_aabb-inter_points_gt,0).all())
 
+            # Use precomputed tree
+            C,W,CH,_,_,tri_ind = gpytoolbox.initialize_aabbtree(v,F=f)
+            sqrD_aabb,ind_aabb,lmb_aabb = gpytoolbox.squared_distance(P,v,F=f,use_aabb=True,C=C,W=W,tri_ind=tri_ind,CH=CH)
+            inter_points_aabb = np.vstack( (
+                lmb_aabb[:,0]*v[f[ind_aabb,0],0] + lmb_aabb[:,1]*v[f[ind_aabb,1],0] + lmb_aabb[:,2]*v[f[ind_aabb,2],0],
+                lmb_aabb[:,0]*v[f[ind_aabb,0],1] + lmb_aabb[:,1]*v[f[ind_aabb,1],1]+ lmb_aabb[:,2]*v[f[ind_aabb,2],1],
+                lmb_aabb[:,0]*v[f[ind_aabb,0],2] + lmb_aabb[:,1]*v[f[ind_aabb,1],2]+ lmb_aabb[:,2]*v[f[ind_aabb,2],2]
+            )).T
+            self.assertTrue(np.isclose(sqrD_aabb-sqrD_gt,0).all())
+            self.assertTrue(np.isclose(inter_points_aabb-inter_points_gt,0).all())
+
 
 
 


### PR DESCRIPTION
This allows one to specify a precomputed AABB tree to ray mesh intersec and point-to-mesh distance queries