### PR TITLE
fixing pip build error

### DIFF
--- a/.github/workflows/ciwheels.yml
+++ b/.github/workflows/ciwheels.yml
@@ -48,7 +48,7 @@ jobs:
       # CIBW_BUILD: cp37-*
       CIBW_BUILD_VERBOSITY: 3
       CIBW_BEFORE_BUILD_LINUX : "yum remove -y cmake && python -m pip install\ cmake && yum -y install gmp-devel\ mpfr-devel && python -m pip install numpy"
-      CIBW_BEFORE_BUILD_MACOS: "python -m pip install numpy"
+      CIBW_BEFORE_BUILD_MACOS: "python -m pip install cython numpy"
       CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install numpy && python -m pip install delvewheel"
       # This is very dubious... It *may* work because these are just cpp libraries that should not depend on the python version. Still, super-dubious.
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "python -m delvewheel repair --no-mangle-all --add-path build\\temp.win-amd64-3.6\\Release;build\\temp.win-amd64-3.6\\Release\\Release;build\\temp.win-amd64-3.6\\Release\\_deps\\gmp-src\\lib;build\\temp.win-amd64-3.6\\Release\\_deps\\mpfr-src\\lib -w {dest_dir} {wheel} "


### PR DESCRIPTION
It seems like the PyPi wheel for gpytoolbox in MacOs fails intermitently (it didn't use to fail, but pushing a trivial commit made it fail one hour after succeeding). It fails at [installing numpy](https://github.com/sgsellan/gpytoolbox/actions/runs/3770842254/jobs/6410920276)!