### PR TITLE
remove_unreferenced

### DIFF
--- a/src/gpytoolbox/__init__.py
+++ b/src/gpytoolbox/__init__.py
@@ -80,3 +80,4 @@ from .angle_defect import angle_defect
 from .angle_defect_intrinsic import angle_defect_intrinsic
 from .grid_neighbors import grid_neighbors
 from .grid_laplacian_eigenfunctions import grid_laplacian_eigenfunctions
+from .remove_unreferenced import remove_unreferenced

--- a/src/gpytoolbox/decimate.py
+++ b/src/gpytoolbox/decimate.py
@@ -23,9 +23,9 @@ def decimate(V,F,face_ratio=0.1,num_faces=None):
     G : numpy int array
         Matrix of triangle indices
     I : numpy int array
-        Vector of indeces into F of the original faces in G
+        Vector of indices into F of the original faces in G
     J : numpy int array
-        Vector of indeces into V of the original vertices in U
+        Vector of indices into V of the original vertices in U
 
     See Also
     --------

--- a/src/gpytoolbox/remove_unreferenced.py
+++ b/src/gpytoolbox/remove_unreferenced.py
@@ -1,0 +1,98 @@
+import numpy as np
+
+def remove_unreferenced(V, F,
+    return_maps=False):
+    """Removes vertices from a vertex-list-face-list polyline or mesh that are
+    unreferenced in the face list.
+    This can be useful to prevent, for example, a mass matrix that is not
+    invertible because of vertices that are declared in a vertex list, but never
+    used in the face list.
+
+    This function will silently skip `-1` entries in `F`.
+    You can use this, for example, to mark invalid vertices that are to be
+    skipped.
+
+
+    Parameters
+    ----------
+    V : (n,d) numpy array or None
+        vertex list of a mesh.
+        If this is None, will assume a mesh with max(F)+1 vertices.
+    F : (m,k) numpy int array
+        index list of a polyline/triangle mesh/tet mesh
+    return_maps : bool, optional (default False)
+        If True, will return mapping arrays `I` and `J` that can be used to map
+        between the new and old vertex indices.
+
+    Returns
+    -------
+    newV : (n1,d) numpy array or None
+           vertex list with unreferenced vertices removed, or None if V is None.
+    newF : (m1,d) numpy int array
+           index list with unreferenced vertices removed
+    I : (n,) or (n+1,) numpy int array, if requested
+        index list such that `I[F] == newF`.
+        `I` is of length `(n,)` if `F` does not contain `-1`, and of length
+        `(n+1,)` if `F` does contain `-1`.
+    J : (n1,) numpy int array, if requested
+        index list such that `V[J,:] = newV`.
+
+    See Also
+    --------
+    libigl's remove_unreferenced, which this function is inspired by, but does
+    not perfectly mirror (in the presence of `-1` in the face list, `-1` will be
+    appended to the return value `I` to ensure that `I(F) == newF`).
+
+    Examples
+    --------
+    ```python
+    >>> V = np.array([[0.,0.],[1.,0.],[0.,1.],[-1.,-2.],[1.,1.]])
+    >>> F = np.array([[0,1,2],[2,1,4]])
+    >>> newV, newF, I, J = gpy.remove_unreferenced(V, F, return_maps=True)
+    >>> newV
+    array([[0., 0.],
+           [1., 0.],
+           [0., 1.],
+           [1., 1.]])
+    >>> newF
+    array([[0, 1, 2],
+           [2, 1, 3]])
+    >>> I
+    array([ 0,  1,  2, -1,  3])
+    >>> J
+    array([0, 1, 2, 4])
+    ```
+    
+    """
+
+    assert (F>=-1).all(), "The only allowed negative value is -1."
+    if V is None:
+        n = np.max(F)+1
+    else:
+        n = V.shape[0]
+        assert np.max(F)<n, "V is too small for F."
+
+    J,idx,newF = np.unique(F, return_index=True, return_inverse=True)
+    if len(J)<1:
+        emptyV = None if V is None else np.array([],dtype=V.dtype)
+        emptyF = np.array([],dtype=F.dtype)
+        if return_maps:
+            return emptyV, emptyF, emptyF.copy(), emptyF.copy()
+        else:
+            return emptyV, emptyF
+    if J[0] == -1:
+        J = J[1:]
+        newF -= 1
+        I = np.full((n+1,), -1)
+    else:
+        I = np.full((n,), -1)
+    I[J] = np.arange(len(J))
+    newF = newF.reshape(F.shape)
+    newV = None if V is None else V[J,:]
+    
+    if return_maps:
+        return newV, newF, I, J
+    else:
+        return newV, newF
+
+

--- a/test/test_remove_unreferenced.py
+++ b/test/test_remove_unreferenced.py
@@ -1,0 +1,117 @@
+from .context import gpytoolbox as gpy
+from .context import numpy as np
+from .context import unittest
+
+
+class TestRemoveUnreferenced(unittest.TestCase):
+
+    def test_polyline(self):
+        V = np.array([[0],[0.2],[0.5],[0.98],[1.0],[1.4],[2.0],[0.3],
+            [0.7],[1.2],[4.5]])
+        F = np.array([[0,1],[1,2],[2,5],[5,3],[3,9]])
+        newV,newF,I,J = gpy.remove_unreferenced(V, F, return_maps=True)
+        newV1,newF1 = gpy.remove_unreferenced(V, F)
+        newV2,newF2 = gpy.remove_unreferenced(None, F)
+        self.assertTrue((newV == newV1).all())
+        self.assertTrue(newV2 is None)
+        self.assertTrue((newF == newF1).all())
+        self.assertTrue((newF == newF2).all())
+        self.assertTrue(np.all(newV == np.array([[0.  ],
+            [0.2 ],
+            [0.5 ],
+            [0.98],
+            [1.4 ],
+            [1.2 ]])))
+        self.assertTrue(np.all(newF == np.array([[0, 1],
+            [1, 2],
+            [2, 4],
+            [4, 3],
+            [3, 5]])))
+        self.assertTrue(np.all(I == np.array([ 0,
+            1,
+            2,
+            3,
+            -1,
+            4,
+            -1,
+            -1,
+            -1,
+            5,
+            -1])))
+        self.assertTrue(np.all(J == np.array([0,
+            1,
+            2,
+            3,
+            5,
+            9])))
+
+        k = 5
+        n = 200
+        m = 20
+        rng = np.random.default_rng()
+        for i in range(k):
+            V = rng.random((n,2))
+            F = rng.integers(-1, n, size=(m,2))
+            newV,newF,I,J = gpy.remove_unreferenced(V, F, return_maps=True)
+            newV1,newF1 = gpy.remove_unreferenced(V, F)
+            newV2,newF2 = gpy.remove_unreferenced(None, F)
+            self.assertTrue((newV == newV1).all())
+            self.assertTrue(newV2 is None)
+            self.assertTrue((newF == newF1).all())
+            self.assertTrue((newF == newF2).all())
+            self.consistency(V, F, newV, newF, I, J)
+
+    def test_triangle_mesh(self):
+        V,F = gpy.read_mesh("test/unit_tests_data/bunny_oded.obj")
+        newV,newF,I,J = gpy.remove_unreferenced(V, F, return_maps=True)
+        newV1,newF1 = gpy.remove_unreferenced(V, F)
+        newV2,newF2 = gpy.remove_unreferenced(None, F)
+        self.assertTrue((newV == newV1).all())
+        self.assertTrue(newV2 is None)
+        self.assertTrue((newF == newF1).all())
+        self.assertTrue((newF == newF2).all())
+        self.assertTrue(np.all(V == newV))
+        self.assertTrue(np.all(F == newF))
+
+        k = 5
+        n = 200
+        m = 20
+        rng = np.random.default_rng()
+        for i in range(k):
+            V = rng.random((n,3))
+            F = rng.integers(-1, n, size=(m,3))
+            newV,newF,I,J = gpy.remove_unreferenced(V, F, return_maps=True)
+            newV1,newF1 = gpy.remove_unreferenced(V, F)
+            newV2,newF2 = gpy.remove_unreferenced(None, F)
+            self.assertTrue((newV == newV1).all())
+            self.assertTrue(newV2 is None)
+            self.assertTrue((newF == newF1).all())
+            self.assertTrue((newF == newF2).all())
+            self.consistency(V, F, newV, newF, I, J)
+
+    def test_tet_mesh(self):
+        k = 5
+        n = 200
+        m = 20
+        rng = np.random.default_rng()
+        for i in range(k):
+            V = rng.random((n,3))
+            F = rng.integers(-1, n, size=(m,4))
+            newV,newF,I,J = gpy.remove_unreferenced(V, F, return_maps=True)
+            newV1,newF1 = gpy.remove_unreferenced(V, F)
+            newV2,newF2 = gpy.remove_unreferenced(None, F)
+            self.assertTrue((newV == newV1).all())
+            self.assertTrue(newV2 is None)
+            self.assertTrue((newF == newF1).all())
+            self.assertTrue((newF == newF2).all())
+            self.consistency(V, F, newV, newF, I, J)
+
+
+    def consistency(self,V,F,newV,newF,I,J):
+        if V is not None:
+            self.assertTrue(np.all(V[J,:] == newV))
+        self.assertTrue(np.all(I[F] == newF))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding function to remove unreferenced vertices, similar to libigl's [remove_unreferenced](https://github.com/libigl/libigl/blob/main/include/igl/remove_unreferenced.h).

Also fixing an occurrence of indeces/indices.