### PR TITLE
Clarifying license terms on contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,7 @@ not already in this library, is remotely related to geometry processing, and you
 have used or used in any of your past projects, we encourage you to submit it
 *as-is* in a Pull Request. We will gladly credit you in the individual function
 as well as on this home page.
+
+Note that the code that you contribute will be licensed under the MIT license.
+Everybody will be able to use this code as long as they credit gpytoolbox
+(and not you individually).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ have used or used in any of your past projects, we encourage you to submit it
 *as-is* in a Pull Request. We will gladly credit you in the individual function
 as well as on this home page.
 
+Note that the code that you contribute will be licensed under the MIT license.
+Everybody will be able to use this code as long as they credit gpytoolbox
+(and not you individually).
+
 ## License
 
 Gpytoolbox's is released under an MIT license ([see details](/LICENSE.MIT)),


### PR DESCRIPTION
Added a comment to README.md and CONTRIBUTING.md informing contributors about the license of their contributions.