### PR TITLE
remesh_botsch - keep indices of feature nodes

### DIFF
--- a/src/gpytoolbox/remesh_botsch.py
+++ b/src/gpytoolbox/remesh_botsch.py
@@ -30,6 +30,11 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
     G : numpy int array
         Matrix of output triangle mesh indices into U
 
+
+    Notes
+    -----
+    The ordering of the output can be somewhat confusing. The output vertices are ordered as follows: [feature vertices, boundary vertices, other vertices]. If a vertex is both a feature and boundary one, it is treated as a feature vertex for the purposes of the ordering. For a more in-depth explanation see [PR #45](https://github.com/sgsellan/gpytoolbox/pull/45).
+
     Examples
     --------
     ```python

--- a/src/gpytoolbox/remesh_botsch.py
+++ b/src/gpytoolbox/remesh_botsch.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 from gpytoolbox.boundary_vertices import boundary_vertices
 from gpytoolbox.halfedge_lengths import halfedge_lengths
 
@@ -18,8 +19,7 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
     h : double, optional (default 0.1)
         Desired edge length (if None, will pick average edge length)
     feature : numpy int array, optional (default np.array([],dtype=int))
-        List of indices of feature vertices that should not change (i.e., they will also be in the output)
-        They will be placed at the beginning of the output array in the same order (as long as they were unique).
+        List of indices of feature vertices that should not change (i.e., they will also be in the output). They will be placed at the beginning of the output array in the same order (as long as they were unique).
     project : bool, optional (default True)
         Whether to reproject the mesh to the input (otherwise, it will smooth over iterations).
 
@@ -47,10 +47,12 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
     if (h is None):
         h = np.mean(halfedge_lengths(V,F))
 
+    # check that feature is unique
+    if feature.shape[0] > 0:
+        if np.unique(feature).shape[0] != feature.shape[0]:
+            warnings.warn("Feature array is not unique. We will compute its unique entries and use those as an input. We recommend you do this yourself to avoid this warning.")
+
     feature = np.concatenate((feature,boundary_vertices(F)),dtype=np.int32)
-    # print(feature)
-    # print(boundary_vertices(F))
-    # bV = boundary_vertices(F)
 
     # reorder feature nodes to the beginning of the array
     if feature.shape[0] > 0:

--- a/src/gpytoolbox/remesh_botsch.py
+++ b/src/gpytoolbox/remesh_botsch.py
@@ -62,11 +62,11 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
         # number of vertices
         n_vertices = V.shape[0]
         # 0 ... n_vertices array
-        old_order = np.arange(n_vertices)
+        old_order = np.arange(n_vertices, dtype=np.int32)
         # new order
-        order = np.concatenate((feature, np.delete(old_order, feature)))
+        order = np.concatenate((feature, np.delete(old_order, feature)), dtype=np.int32)
         # generate tmp array for reordering mesh indices
-        tmp = np.empty(n_vertices, dtype=order.dtype)
+        tmp = np.empty(n_vertices, dtype=np.int32)
         tmp[order] = old_order  # this line will fail if features are not unique
 
         # reorder vertex coordinates

--- a/test/test_remesh_botsch.py
+++ b/test/test_remesh_botsch.py
@@ -47,6 +47,40 @@ class TestRemeshBotsch(unittest.TestCase):
             dist = np.min(np.linalg.norm(np.tile(boundary_verts[i,:][None,:],(boundary_verts_output.shape[0],1)) - boundary_verts_output,axis=1))
             self.assertTrue(dist==0.0)
 
+    def test_with_unique_features(self):
+        np.random.seed(0)
+        v,f = gpytoolbox.read_mesh("test/unit_tests_data/bunny.obj")
+        # pick random faces of the model that are fixed
+        feature = f[np.random.choice(range(f.shape[0]), v.shape[0]//1000, replace=False)].flatten()
+        u,g = gpytoolbox.remesh_botsch(v,f.astype(np.int32),20,0.01,True,feature=feature)
+        self.assertTrue(np.allclose(v[feature], u[:feature.shape[0]]))
+
+    def test_with_not_unique_features(self):
+        np.random.seed(8)
+        v,f = gpytoolbox.read_mesh("test/unit_tests_data/bunny.obj")
+        # pick random faces of the model that are fixed
+        feature = f[np.random.choice(range(f.shape[0]), v.shape[0]//1000, replace=False)].flatten()
+        # check that they are not unique
+        self.assertFalse(feature.shape[0] == np.unique(feature).shape[0])
+        u,g = gpytoolbox.remesh_botsch(v,f.astype(np.int32),20,0.01,True,feature=feature)
+        # unique feature nodes
+        tmp, ind = np.unique(feature, return_index=True)
+        feature_unique = tmp[np.argsort(ind)]
+        self.assertTrue(np.allclose(v[feature_unique], u[:feature_unique.shape[0]]))
+
+    def test_with_not_unique_features_and_boundary(self):
+        np.random.seed(8)
+        v,f = gpytoolbox.read_mesh("test/unit_tests_data/bunny.obj")
+        # pick random faces of the model that are fixed and add some boundary nodes
+        feature = f[np.random.choice(range(f.shape[0]), v.shape[0]//1000, replace=False)].flatten()
+        feature = np.concatenate((feature, np.random.choice(gpytoolbox.boundary_vertices(f), 20, replace=False)))
+        # check that they are not unique
+        self.assertFalse(feature.shape[0] == np.unique(feature).shape[0])
+        u,g = gpytoolbox.remesh_botsch(v,f.astype(np.int32),20,0.01,True,feature=feature)
+        # unique feature nodes
+        tmp, ind = np.unique(feature, return_index=True)
+        feature_unique = tmp[np.argsort(ind)]
+        self.assertTrue(np.allclose(v[feature_unique], u[:feature_unique.shape[0]]))
 
     # def test_github_issue_30(self):
     #     np.random.seed(0)

--- a/test/test_remesh_botsch.py
+++ b/test/test_remesh_botsch.py
@@ -47,6 +47,14 @@ class TestRemeshBotsch(unittest.TestCase):
             dist = np.min(np.linalg.norm(np.tile(boundary_verts[i,:][None,:],(boundary_verts_output.shape[0],1)) - boundary_verts_output,axis=1))
             self.assertTrue(dist==0.0)
 
+    def test_with_unique_features_closed(self):
+        np.random.seed(0)
+        v,f = gpytoolbox.read_mesh("test/unit_tests_data/bunny_oded.obj")
+        # pick random faces of the model that are fixed
+        feature = f[np.random.choice(range(f.shape[0]), v.shape[0]//1000, replace=False)].flatten()
+        u,g = gpytoolbox.remesh_botsch(v,f.astype(np.int32),20,0.01,True,feature=feature)
+        self.assertTrue(np.allclose(v[feature], u[:feature.shape[0]]))
+
     def test_with_unique_features(self):
         np.random.seed(0)
         v,f = gpytoolbox.read_mesh("test/unit_tests_data/bunny.obj")


### PR DESCRIPTION
Sort feature and boundary vertices to the beginning of the vertex array to maintain indices after remeshing.
See https://github.com/sgsellan/gpytoolbox/issues/30

Keeps their order if possible 
1.  unique feature nodes in their given order ( [0, 1, 7, 4, 7, 5] => [0, 1, 7, 4, 5])
2. boundary nodes

We can discuss if the boundary vertices should not be sorted subsequently to the feature vertices.
I think is an addition "nice to have".
Otherwise we still need to ensure the combined feature vertices (externally given, concatenated with the boundary vertices) need to be unique for the remesh algorithm (do we?)
