### PR TITLE
Make array correspondence simpler, slightly safer, and make API more numpy-like

### DIFF
--- a/src/gpytoolbox/array_correspondence.py
+++ b/src/gpytoolbox/array_correspondence.py
@@ -25,60 +25,18 @@ def array_correspondence(A,B,axis=None):
     TODO
     
     """
+    A = A.ravel()
+    B = B.ravel()
 
-    if axis is None:
-        A = A.ravel()
-        B = B.ravel()
-
-        # Slow for loop
-        # f = np.full(A.size, -1, dtype=np.int64)
-        # for a in range(A.size):
-        #     for b in range(B.size):
-        #         if A[a]==B[b]:
-        #             f[a] = b
-
-        # While we have to keep track of duplicates in A (to map them to the
-        # correct place), we do not care about duplicates in B
-        uB,mapB = np.unique(B, return_index=True)
-        _,idx,inv = np.unique(np.concatenate((uB,A)),
-            return_index=True, return_inverse=True)
-        imap = idx[inv[uB.size:]]
-        imap[imap>=uB.size] = -1
-        f = np.where(imap<0, -1, mapB[imap])
-
-    else:
-        assert len(A.shape) == 2
-        assert len(B.shape) == 2
-        assert axis==-2 or axis==-1 or axis==0 or axis==1
-        assert A.shape[axis] == B.shape[axis]
-
-        # This function compares rows, so we reduce the problem to rows here.
-        if axis==-2 or axis==0:
-                A = A.transpose()
-                B = B.transpose()
-
-        # # https://stackoverflow.com/a/64930992 is too memory-intensive
-        # inds = (A[None,:,:] == B[:,None,:])
-        # i,j = np.nonzero(inds.sum(axis=2) == A.shape[1])
-        # f = np.full(A.shape[0], -1, dtype=np.int64)
-        # f[j] = i
-
-        # # Slower (but less memory-intensive) with for loops
-        # f = np.full(A.shape[0], -1, dtype=np.int64)
-        # for a in range(A.shape[0]):
-        #     for b in range(B.shape[0]):
-        #         if (A[a,:]==B[b,:]).all():
-        #             f[a] = b
-
-        # Convert each row to bytes, intersect byte arrays in 1d
-        def to_byte_array(x):
-            # Adapted from https://stackoverflow.com/a/54683422
-            dt = np.dtype('S{:d}'.format(x.shape[1] * x.dtype.itemsize))
-            return np.frombuffer(x.tobytes(), dtype=dt)
-        bytesA = to_byte_array(A)
-        bytesB = to_byte_array(B.astype(A.dtype))
-        f = array_correspondence(bytesA,bytesB,axis=None)
-
+    # While we have to keep track of duplicates in A (to map them to the
+    # correct place), we do not care about duplicates in B
+    uB,mapB = np.unique(B, return_index=True, axis=axis)
+    _,idx,inv = np.unique(np.concatenate((uB,A)),
+        return_index=True, return_inverse=True, axis=axis)
+    imap = idx[inv[uB.size:]]
+    imap[imap>=uB.size] = -1
+    f = np.where(imap<0, -1, mapB[imap])
+    
     return f
 
 

--- a/test/test_array_correspondence.py
+++ b/test/test_array_correspondence.py
@@ -51,6 +51,17 @@ class TestArrayCorrespondence(unittest.TestCase):
             self.mapping_condition(A, B, ft)
             fti = gpy.array_correspondence(B.transpose(),A.transpose(),axis=0)
             self.mapping_condition(B, A, fti)
+    
+    def test_objects(self):
+        class A():
+            pass
+        a_ptr_0 = A()
+        a_ptr_1 = a_ptr_0
+        a_ptr_2 = a_ptr_1
+        A = np.array([a_ptr_0, a_ptr_1, a_ptr_2, a_ptr_0, A(), A(), A()])
+        B = np.array([A(), A(), A(), a_ptr_0])
+        f = gpy.array_correspondence(A, B, axis=None)
+        self.mapping_condition(A, B, f)
 
     def mapping_condition(self, A, B, f):
         self.assertTrue(f.shape[0] == A.shape[0])

--- a/test/test_array_correspondence.py
+++ b/test/test_array_correspondence.py
@@ -53,15 +53,23 @@ class TestArrayCorrespondence(unittest.TestCase):
             self.mapping_condition(B, A, fti)
     
     def test_objects(self):
-        class A():
-            pass
-        a_ptr_0 = A()
+        class Aobj():
+            def __init__(self, val=5):
+                self.val = val
+            def __eq__(self, other):
+                return self.val == other.val
+            def __lt__(self, other):
+                return self.val < other.val
+        a_ptr_0 = Aobj(9)
         a_ptr_1 = a_ptr_0
         a_ptr_2 = a_ptr_1
-        A = np.array([a_ptr_0, a_ptr_1, a_ptr_2, a_ptr_0, A(), A(), A()])
-        B = np.array([A(), A(), A(), a_ptr_0])
-        f = gpy.array_correspondence(A, B, axis=None)
-        self.mapping_condition(A, B, f)
+        a_ptr_4 = Aobj(5)
+        A = np.array([[a_ptr_0], [a_ptr_1], [a_ptr_2], [a_ptr_0], [Aobj(2)], [Aobj(2)], [Aobj(8)], [a_ptr_4]])
+        B = np.array([[Aobj(5)], [Aobj(2)], [Aobj(4)], [a_ptr_0]])
+        f0 = gpy.array_correspondence(A, B, axis=1)
+        f1 = gpy.array_correspondence(A[..., 0], B[..., 0], axis=1)
+        self.mapping_condition(A, B, f0)
+        self.mapping_condition(A[..., 0], B[..., 0], f1)
 
     def mapping_condition(self, A, B, f):
         self.assertTrue(f.shape[0] == A.shape[0])


### PR DESCRIPTION
This new array correspondence makes:

1. The API more numpy-like. The axis now specifies the dimension to do the correspondence search over.
2. Adds some asserts for safety.
3. Some simple comments to explain what the code is doing.
4. Replace the byte comparison (which will amount to pointer comparisons to objects) with multi-dim `np.unique` which is a bit more readable and works for single-dim object arrays.

Unfortunately `np.unique` doesn't work well for multi-dim object arrays... but these would've failed in the any case in the older version so at least it's not a regression. 