### PR TITLE
Add a warning in remesch_botsch if all vertices are detected as boundary vertices

### DIFF
--- a/src/gpytoolbox/remesh_botsch.py
+++ b/src/gpytoolbox/remesh_botsch.py
@@ -62,10 +62,6 @@ def remesh_botsch(V, F, i=10, h=None, project=True, feature=np.array([], dtype=i
 
     feature = np.concatenate((feature, boundary_vertices(F)), dtype=np.int32)
 
-    # check that at least one vertex is not a boundary vertex
-    if feature.shape[0] == V.shape[0]:
-        warnings.warn("All vertices are detected as boundary vertices. The result will be the input mesh.")
-
     # reorder feature nodes to the beginning of the array (contributed by Michael Jäger)
     if feature.shape[0] > 0:
         # feature indices need to be unique (including the boundary_vertices)
@@ -89,6 +85,10 @@ def remesh_botsch(V, F, i=10, h=None, project=True, feature=np.array([], dtype=i
         F = tmp[F]
         # features are now 0 to n_features
         feature = old_order[:feature.shape[0]]
+
+    # check that at least one vertex is not a boundary vertex
+    if feature.shape[0] == V.shape[0]:
+        warnings.warn("All vertices are detected as boundary vertices. The result will be the input mesh.")
 
     v, f = _remesh_botsch_cpp_impl(V, F.astype(np.int32), i, h, feature, project)
 

--- a/src/gpytoolbox/remesh_botsch.py
+++ b/src/gpytoolbox/remesh_botsch.py
@@ -3,7 +3,8 @@ import warnings
 from gpytoolbox.boundary_vertices import boundary_vertices
 from gpytoolbox.halfedge_lengths import halfedge_lengths
 
-def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int)):
+
+def remesh_botsch(V, F, i=10, h=None, project=True, feature=np.array([], dtype=int)):
     """Remesh a triangular mesh to have a desired edge length
     
     Use the algorithm described by Botsch and Kobbelt's "A Remeshing Approach to Multiresolution Modeling" to remesh a triangular mesh by alternating iterations of subdivision, collapse, edge flips and collapses.
@@ -18,7 +19,7 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
         Number of algorithm iterations
     h : double, optional (default 0.1)
         Desired edge length (if None, will pick average edge length)
-    feature : numpy int array, optional (default np.array([],dtype=int))
+    feature : numpy int array, optional (default np.array([], dtype=int))
         List of indices of feature vertices that should not change (i.e., they will also be in the output). They will be placed at the beginning of the output array in the same order (as long as they were unique).
     project : bool, optional (default True)
         Whether to reproject the mesh to the input (otherwise, it will smooth over iterations).
@@ -39,25 +40,31 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
     --------
     ```python
     # Read a mesh
-    v,f = gpytoolbox.read_mesh("bunny_oded.obj")
+    v, f = gpytoolbox.read_mesh("bunny_oded.obj")
     # Do 20 iterations of remeshing with a target length of 0.01
-    u,g = gpytoolbox.remesh_botsch(v,f,20,0.01,True)
+    u, g = gpytoolbox.remesh_botsch(v, f, 20, 0.01, True)
     ```
     """
     try:
         from gpytoolbox_bindings import _remesh_botsch_cpp_impl
     except:
         raise ImportError("Gpytoolbox cannot import its C++ binding.")
-    
-    if (h is None):
-        h = np.mean(halfedge_lengths(V,F))
+
+    if h is None:
+        h = np.mean(halfedge_lengths(V, F))
 
     # check that feature is unique
     if feature.shape[0] > 0:
         if np.unique(feature).shape[0] != feature.shape[0]:
-            warnings.warn("Feature array is not unique. We will compute its unique entries and use those as an input. We recommend you do this yourself to avoid this warning.")
+            warnings.warn(
+                "Feature array is not unique. We will compute its unique entries and use those as an input. "
+                "We recommend you do this yourself to avoid this warning.")
 
-    feature = np.concatenate((feature,boundary_vertices(F)),dtype=np.int32)
+    feature = np.concatenate((feature, boundary_vertices(F)), dtype=np.int32)
+
+    # check that at least one vertex is not a boundary vertex
+    if feature.shape[0] == V.shape[0]:
+        warnings.warn("All vertices are detected as boundary vertices. The result will be the input mesh.")
 
     # reorder feature nodes to the beginning of the array (contributed by Michael Jäger)
     if feature.shape[0] > 0:
@@ -83,6 +90,6 @@ def remesh_botsch(V,F,i=10,h=None,project=True,feature = np.array([],dtype=int))
         # features are now 0 to n_features
         feature = old_order[:feature.shape[0]]
 
-    v,f = _remesh_botsch_cpp_impl(V,F.astype(np.int32),i,h,feature,project)
+    v, f = _remesh_botsch_cpp_impl(V, F.astype(np.int32), i, h, feature, project)
 
-    return v,f
+    return v, f


### PR DESCRIPTION
If all vertices of a mesh are detected as boundary vertices, the remesh_botsch will return the input.
I've added a warning to make the user aware in this case (L65 - L67).

Additionally, I applied PEP8 style guide (whitespace) to the code.