### PR TITLE
fixes #104

### DIFF
--- a/src/gpytoolbox/marching_squares.py
+++ b/src/gpytoolbox/marching_squares.py
@@ -180,6 +180,12 @@ def marching_squares(S,GV,nx,ny):
     # Convert list to numpy array
     verts = np.array(verts)
     edges = np.array(edge_list)
+
+    # if it's empty, no need to do anything else.
+    if verts.shape[0] == 0:
+        assert edges.shape[0] == 0
+        return verts, edges
+
     verts, SVI, SVJ, edges = remove_duplicate_vertices(verts,faces=edges,
         epsilon=np.sqrt(np.finfo(verts.dtype).eps))
 

--- a/test/test_marching_squares.py
+++ b/test/test_marching_squares.py
@@ -82,6 +82,15 @@ class TestMarchingSquares(unittest.TestCase):
         S2 = gpytoolbox.signed_distance(GV, verts, edge_list)[0]
         self.assertTrue(np.allclose(S1,S2,atol=1e-2))
 
+    def test_empty(self):
+        n = 250
+        gx, gy = np.meshgrid(np.linspace(-1.0, 1.0, n+1), np.linspace(-1.0, 1.0, n+1))
+        GV = np.vstack((gx.flatten(), gy.flatten())).T
+        S = np.ones((GV.shape[0],1))
+        # this used to cause a crash
+        verts, edge_list = gpytoolbox.marching_squares(S, GV, n+1, n+1)
+        self.assertTrue(verts.shape[0]==0)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tiny change that makes marching squares not crash if the output is empty