### PR TITLE
adding triangulation and tetrahedralization functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Bindings
 	DESCRIPTION
-		"Python libigl bindings"
+		"Python bindings"
 )
 
 set(CMAKE_CXX_STANDARD 17)
@@ -23,9 +23,19 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 endif()
 
 
+# Include libigl
 option(LIBIGL_COPYLEFT_CGAL "Use CGAL"          ON)
+option(LIBIGL_COPYLEFT_TETGEN "Use Tetgen"      ON)
 option(LIBIGL_EMBREE "Build target igl::embree" ON)
 include(libigl)
+
+# Add triangulation library.
+include(CDT)
+add_subdirectory("${CMAKE_BINARY_DIR}/_deps/cdt-src/CDT/" CDT)
+
+# List of all libraries to link
+set(LIBRARIES_TO_LINK igl::core igl::embree CDT)
+set(COPYLEFT_LIBRARIES_TO_LINK igl::core igl_copyleft::cgal igl_copyleft::tetgen)
 
 add_library(cpytoolbox
 	STATIC
@@ -81,9 +91,10 @@ add_library(cpytoolbox
 	src/cpp/swept_volume/swept_volume.h
 	)
 
-# target_link_libraries(cpytoolbox igl::core igl_copyleft::cgal igl::embree)
-target_link_libraries(cpytoolbox igl::core igl::embree )
-target_link_libraries(cpytoolbox_copyleft igl::core igl_copyleft::cgal)
+target_link_libraries(cpytoolbox ${LIBRARIES_TO_LINK})
+set(LIBRARIES_TO_LINK cpytoolbox ${LIBRARIES_TO_LINK})
+target_link_libraries(cpytoolbox_copyleft ${COPYLEFT_LIBRARIES_TO_LINK})
+set(COPYLEFT_LIBRARIES_TO_LINK cpytoolbox_copyleft ${COPYLEFT_LIBRARIES_TO_LINK})
 
 # Otman's python bindings using pybind11
 add_subdirectory(./ext/pybind11/)
@@ -106,16 +117,18 @@ pybind11_add_module(gpytoolbox_bindings
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_read_ply.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_write_ply.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_curved_hessian_intrinsic.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_triangulate.cpp"
 )
 
 pybind11_add_module(gpytoolbox_bindings_copyleft
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/gpytoolbox_bindings_copyleft_core.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_swept_volume.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/gpytoolbox_bindings_copyleft_core.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_swept_volume.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_booleans.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_tetrahedralize.cpp"
 )
 
-target_link_libraries(gpytoolbox_bindings PUBLIC cpytoolbox igl::core)
-target_link_libraries(gpytoolbox_bindings_copyleft PUBLIC cpytoolbox_copyleft igl::core igl_copyleft::cgal)
+target_link_libraries(gpytoolbox_bindings PUBLIC ${LIBRARIES_TO_LINK})
+target_link_libraries(gpytoolbox_bindings_copyleft PUBLIC ${COPYLEFT_LIBRARIES_TO_LINK})
 
 target_include_directories(gpytoolbox_bindings PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/LICENSE.AGPL
+++ b/LICENSE.AGPL
@@ -1,0 +1,671 @@
+TetGen License
+--------------
+
+TetGen is distributed under a dual licensing scheme. You can
+redistribute it and/or modify it under the terms of the GNU Affero
+General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later
+version. A copy of the GNU Affero General Public License is reproduced
+below.
+
+If the terms and conditions of the AGPL v.3. would prevent you from
+using TetGen, please consider the option to obtain a commercial
+license for a fee. These licenses are offered by the Weierstrass
+Institute for Applied Analysis and Stochastics (WIAS). As a rule,
+licenses are provided "as-is", unlimited in time for a one time
+fee. Please send corresponding requests to:
+tetgen@wias-berlin.de. Please do not forget to include some
+description of your company and the realm of its activities.
+
+=====================================================================
+GNU AFFERO GENERAL PUBLIC LICENSE
+
+Version 3, 19 November 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Preamble
+
+The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works. By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains
+free software for all its users.
+
+When we speak of free software, we are referring to freedom, not
+price. Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate. Many developers of free software are heartened and
+encouraged by the resulting cooperation. However, in the case of
+software used on network servers, this result may fail to come
+about. The GNU General Public License permits making a modified
+version and letting the public access it on a server without ever
+releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community. It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server. Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals. This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing
+under this license.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public
+License.
+
+"Copyright" also means copyright-like laws that apply to other kinds
+of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this
+License. Each licensee is addressed as "you". "Licensees" and
+"recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of
+an exact copy. The resulting work is called a "modified version" of
+the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies. Mere interaction with a user
+through a computer network, with no transfer of a copy, is not
+conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to
+the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License. If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+
+The "source code" for a work means the preferred form of the work for
+making modifications to it. "Object code" means any non-source form of
+a work.
+
+A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form. A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities. However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work. For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can
+regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same
+work.
+
+2. Basic Permissions.
+
+All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met. This License explicitly affirms your unlimited
+permission to run the unmodified Program. The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work. This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey,
+without conditions so long as your license otherwise remains in
+force. You may convey covered works to others for the sole purpose of
+having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright. Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the
+conditions stated below. Sublicensing is not allowed; section 10 makes
+it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such
+circumvention is effected by exercising rights under this License with
+respect to the covered work, and you disclaim any intention to limit
+operation or modification of the work as a means of enforcing, against
+the work's users, your or third parties' legal rights to forbid
+circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these
+conditions:
+
+a) The work must carry prominent notices stating that you modified it,
+and giving a relevant date.  b) The work must carry prominent notices
+stating that it is released under this License and any conditions
+added under section 7. This requirement modifies the requirement in
+section 4 to "keep intact all notices".  c) You must license the
+entire work, as a whole, under this License to anyone who comes into
+possession of a copy. This License will therefore apply, along with
+any applicable section 7 additional terms, to the whole of the work,
+and all its parts, regardless of how they are packaged. This License
+gives no permission to license the work in any other way, but it does
+not invalidate such permission if you have separately received it.  d)
+If the work has interactive user interfaces, each must display
+Appropriate Legal Notices; however, if the Program has interactive
+interfaces that do not display Appropriate Legal Notices, your work
+need not make them do so.  A compilation of a covered work with other
+separate and independent works, which are not by their nature
+extensions of the covered work, and which are not combined with it
+such as to form a larger program, in or on a volume of a storage or
+distribution medium, is called an "aggregate" if the compilation and
+its resulting copyright are not used to limit the access or legal
+rights of the compilation's users beyond what the individual works
+permit. Inclusion of a covered work in an aggregate does not cause
+this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms of
+sections 4 and 5, provided that you also convey the machine-readable
+Corresponding Source under the terms of this License, in one of these
+ways:
+
+a) Convey the object code in, or embodied in, a physical product
+(including a physical distribution medium), accompanied by the
+Corresponding Source fixed on a durable physical medium customarily
+used for software interchange.  b) Convey the object code in, or
+embodied in, a physical product (including a physical distribution
+medium), accompanied by a written offer, valid for at least three
+years and valid for as long as you offer spare parts or customer
+support for that product model, to give anyone who possesses the
+object code either (1) a copy of the Corresponding Source for all the
+software in the product that is covered by this License, on a durable
+physical medium customarily used for software interchange, for a price
+no more than your reasonable cost of physically performing this
+conveying of source, or (2) access to copy the Corresponding Source
+from a network server at no charge.  c) Convey individual copies of
+the object code with a copy of the written offer to provide the
+Corresponding Source. This alternative is allowed only occasionally
+and noncommercially, and only if you received the object code with
+such an offer, in accord with subsection 6b.  d) Convey the object
+code by offering access from a designated place (gratis or for a
+charge), and offer equivalent access to the Corresponding Source in
+the same way through the same place at no further charge. You need not
+require recipients to copy the Corresponding Source along with the
+object code. If the place to copy the object code is a network server,
+the Corresponding Source may be on a different server (operated by you
+or a third party) that supports equivalent copying facilities,
+provided you maintain clear directions next to the object code saying
+where to find the Corresponding Source. Regardless of what server
+hosts the Corresponding Source, you remain obligated to ensure that it
+is available for as long as needed to satisfy these requirements.  e)
+Convey the object code using peer-to-peer transmission, provided you
+inform other peers where the object code and Corresponding Source of
+the work are being offered to the general public at no charge under
+subsection 6d.  A separable portion of the object code, whose source
+code is excluded from the Corresponding Source as a System Library,
+need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal,
+family, or household purposes, or (2) anything designed or sold for
+incorporation into a dwelling. In determining whether a product is a
+consumer product, doubtful cases shall be resolved in favor of
+coverage. For a particular product received by a particular user,
+"normally used" refers to a typical or common use of that class of
+product, regardless of the status of the particular user or of the way
+in which the particular user actually uses, or expects or is expected
+to use, the product. A product is a consumer product regardless of
+whether the product has substantial commercial, industrial or
+non-consumer uses, unless such uses represent the only significant
+mode of use of the product.
+
+"Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to
+install and execute modified versions of a covered work in that User
+Product from a modified version of its Corresponding Source. The
+information must suffice to ensure that the continued functioning of
+the modified object code is in no case prevented or interfered with
+solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information. But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or
+updates for a work that has been modified or installed by the
+recipient, or for the User Product in which it has been modified or
+installed. Access to a network may be denied when the modification
+itself materially and adversely affects the operation of the network
+or violates the rules and protocols for communication across the
+network.
+
+Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+7. Additional Terms.
+
+"Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its
+conditions. Additional permissions that are applicable to the entire
+Program shall be treated as though they were included in this License,
+to the extent that they are valid under applicable law. If additional
+permissions apply only to part of the Program, that part may be used
+separately under those permissions, but the entire Program remains
+governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it. (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.) You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders
+of that material) supplement the terms of this License with terms:
+
+a) Disclaiming warranty or limiting liability differently from the
+terms of sections 15 and 16 of this License; or b) Requiring
+preservation of specified reasonable legal notices or author
+attributions in that material or in the Appropriate Legal Notices
+displayed by works containing it; or c) Prohibiting misrepresentation
+of the origin of that material, or requiring that modified versions of
+such material be marked in reasonable ways as different from the
+original version; or d) Limiting the use for publicity purposes of
+names of licensors or authors of the material; or e) Declining to
+grant rights under trademark law for use of some trade names,
+trademarks, or service marks; or f) Requiring indemnification of
+licensors and authors of that material by anyone who conveys the
+material (or modified versions of it) with contractual assumptions of
+liability to the recipient, for any liability that these contractual
+assumptions directly impose on those licensors and authors.  All other
+non-permissive additional terms are considered "further restrictions"
+within the meaning of section 10. If the Program as you received it,
+or any part of it, contains a notice stating that it is governed by
+this License along with a term that is a further restriction, you may
+remove that term. If a license document contains a further restriction
+but permits relicensing or conveying under this License, you may add
+to a covered work material governed by the terms of that license
+document, provided that the further restriction does not survive such
+relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions; the
+above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly
+provided under this License. Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+However, if you cease all violation of this License, then your license
+from a particular copyright holder is reinstated (a) provisionally,
+unless and until the copyright holder explicitly and finally
+terminates your license, and (b) permanently, if the copyright holder
+fails to notify you of the violation by some reasonable means prior to
+60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License. If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run
+a copy of the Program. Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance. However,
+nothing other than this License grants you permission to propagate or
+modify any covered work. These actions infringe copyright if you do
+not accept this License. Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License. You are not responsible
+for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations. If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License. For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based. The
+work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned
+or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version. For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement). To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients. "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the
+scope of its coverage, prohibits the exercise of, or is conditioned on
+the non-exercise of one or more of the rights that are specifically
+granted under this License. You may not convey a covered work if you
+are a party to an arrangement with a third party that is in the
+business of distributing software, under which you make payment to the
+third party based on the extent of your activity of conveying the
+work, and under which the third party grants, to any of the parties
+who would receive the covered work from you, a discriminatory patent
+license (a) in connection with copies of the covered work conveyed by
+you (or copies made from those copies), or (b) primarily for and in
+connection with specific products or compilations that contain the
+covered work, unless you entered into that arrangement, or that patent
+license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License. If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under
+this License and any other pertinent obligations, then as a
+consequence you may not convey it at all. For example, if you agree to
+terms that obligate you to collect a royalty for further conveying
+from those to whom you convey the Program, the only way you could
+satisfy both those terms and this License would be to refrain entirely
+from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public
+License.
+
+Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your
+version supports such interaction) an opportunity to receive the
+Corresponding Source of your version by providing access to the
+Corresponding Source from a network server at no charge, through some
+standard or customary means of facilitating copying of software. This
+Corresponding Source shall include the Corresponding Source for any
+work covered by version 3 of the GNU General Public License that is
+incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work. The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions
+of the GNU Affero General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program
+specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation. If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever
+published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions
+of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+Later license versions may give you additional or different
+permissions. However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT
+WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE
+DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR
+CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT
+NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR
+LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM
+TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER
+PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these
+terms.
+
+To do so, attach the following notices to the program. It is safest to
+attach them to the start of each source file to most effectively state
+the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it
+    does.> Copyright (C) <year> <name of author>
+
+    This program is free software: you can redistribute it and/or
+    modify it under the terms of the GNU Affero General Public License
+    as published by the Free Software Foundation, either version 3 of
+    the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see
+    <http://www.gnu.org/licenses/>.  Also add information on how to
+    contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source. For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code. There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for
+the specific requirements.
+
+You should also get your employer (if you work as a programmer) or
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary. For more information on this, and how to apply and follow
+the GNU AGPL, see <http://www.gnu.org/licenses/>.
+
+
+================================
+
+This library links to code using TetGen in its copyleft module (https://wias-berlin.de/software/tetgen/)

--- a/LICENSE.GPL
+++ b/LICENSE.GPL
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Silvia Sellán and Oded Stein
+Copyright (c) 2024 Silvia Sellán and Oded Stein
                   
                    GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Silvia Sellán and Oded Stein
+Copyright (c) 2024 Silvia Sellán and Oded Stein
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28,3 +28,12 @@ This software contains the ColorBrewer color maps by Cynthia Brewer
 (Pennsylvania State University), released under the Apache 2.0 license
 (http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html),
 and modifications by AxisMaps (https://colorbrewer2.org)
+
+========================
+
+This software includes code from libigl, released under MPL2 (https://github.com/libigl/libigl/blob/main/LICENSE.MPL2)
+
+========================
+
+This software includes code from CDT, released under MPL2 (https://github.com/artem-ogre/CDT/blob/master/LICENSE), and an active pull request by Islam0mar (https://github.com/Islam0mar/CDT/tree/ruppert-delaunay-refinement)
+

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ not you individually).
 ## License
 
 Gpytoolbox's is released under an MIT license ([see details](/LICENSE.MIT)),
-except for files in the `gpytoolbox.copyleft` module, which are under a GPL one
-([see details](/LICENSE.GPL)). Functions in the copyleft module must be imported
+except for files in the `gpytoolbox.copyleft` module, which are under a GPL/AGPL one
+(see [here](/LICENSE.GPL) and [here](/LICENSE.AGPL)). Functions in the copyleft module must be imported
 explicitly; this way, if you import only the main Gpytoolbox module
 ```python
 import gpytoolbox
@@ -120,7 +120,7 @@ import any functionality from `gpytoolbox.copyleft`; e.g.,
 ```python
 from gpytoolbox.copyleft import mesh_boolean
 ```
-you will be bound by the more restrictive GPL license.
+you will be bound by the more restrictive GPL/AGPL license.
 
 ## Attribution
 

--- a/cmake/CDT.cmake
+++ b/cmake/CDT.cmake
@@ -1,0 +1,11 @@
+if(TARGET CDT)
+    return()
+endif()
+
+include(FetchContent)
+FetchContent_Declare(
+    CDT
+    GIT_REPOSITORY https://github.com/artem-ogre/CDT.git
+    GIT_TAG 24ff7d7969dded0243c9e1e992a5398a6d0293dd
+)
+FetchContent_MakeAvailable(CDT)

--- a/src/cpp/binding_tetrahedralize.cpp
+++ b/src/cpp/binding_tetrahedralize.cpp
@@ -1,0 +1,43 @@
+#include <pybind11/stl.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/functional.h>
+#include <string>
+#include <igl/copyleft/tetgen/tetrahedralize.h>
+
+using namespace Eigen;
+namespace py = pybind11;
+using EigenDStride = Stride<Eigen::Dynamic, Eigen::Dynamic>;
+template <typename MatrixType>
+using EigenDRef = Ref<MatrixType, 0, EigenDStride>; //allows passing column/row order matrices easily
+
+void binding_tetrahedralize(py::module& m) {
+    m.def("_tetrahedralize_cpp_impl",[](EigenDRef<MatrixXd> _V,
+                         EigenDRef<MatrixXi> _F,
+                         EigenDRef<MatrixXd> _H,
+                         double max_volume,
+                         double min_rad_edge_ratio)
+        {
+
+            std::ostringstream params_stream;
+            params_stream << "Q";
+            if(max_volume>0) {
+                params_stream << "a" << max_volume;
+            }
+            if(min_rad_edge_ratio>0) {
+                params_stream << "q" << min_rad_edge_ratio;
+            }
+            Eigen::MatrixXd V(_V), H(_H);
+            Eigen::MatrixXi F(_F);
+            Eigen::MatrixXd R,W;
+            Eigen::MatrixXi TR,PT;
+            Eigen::MatrixXi T,TF,FT,TN;
+            size_t numRegions;
+            int status = igl::copyleft::tetgen::tetrahedralize(V,F,H,
+                R,
+                params_stream.str(),
+                W,T,TF,TR,TN,PT,FT,numRegions);
+            return std::make_tuple(status, W, T, TF);
+        });
+    
+}

--- a/src/cpp/binding_triangulate.cpp
+++ b/src/cpp/binding_triangulate.cpp
@@ -1,0 +1,54 @@
+#include <CDT.h>
+#include <pybind11/stl.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/functional.h>
+#include <string>
+
+using namespace Eigen;
+namespace py = pybind11;
+using EigenDStride = Stride<Eigen::Dynamic, Eigen::Dynamic>;
+template <typename MatrixType>
+using EigenDRef = Ref<MatrixType, 0, EigenDStride>; //allows passing column/row order matrices easily
+
+void binding_triangulate(py::module& m) {
+    m.def("_triangulate_cpp_impl",[](EigenDRef<MatrixXd> V,
+                         EigenDRef<MatrixXi> E,
+                         double max_area,
+                         double min_angle,
+                         int max_steiner_points)
+        {
+
+            std::vector<CDT::V2d<double> > vertices;
+            for(int i=0; i<V.rows(); ++i) {
+                vertices.push_back(CDT::V2d<double>::make(V(i,0), V(i,1)));
+            }
+            CDT::Triangulation<double> cdt;
+            cdt.insertVertices(vertices);
+            std::vector<CDT::Edge> edges;
+            if(E.size()>0) {
+                for(int i=0; i<E.rows(); ++i) {
+                    edges.emplace_back(E(i,0), E(i,1));
+                }
+                cdt.conformToEdges(edges);
+            }
+            if(E.size()>0) {
+                cdt.eraseOuterTrianglesAndHoles();
+            } else {
+                cdt.eraseSuperTriangle();
+            }
+            Eigen::MatrixXd W(cdt.vertices.size(), 2);
+            for(int i=0; i<cdt.vertices.size(); ++i) {
+                W.row(i) << cdt.vertices[i].x, cdt.vertices[i].y;
+            }
+            Eigen::MatrixXi F(cdt.triangles.size(), 3);
+            for(int i=0; i<cdt.triangles.size(); ++i) {
+                for(int j=0; j<3; ++j) {
+                    F(i,j) = cdt.triangles[i].vertices[j];
+                }
+            }
+
+            return std::make_tuple(W, F);
+        });
+    
+}

--- a/src/cpp/gpytoolbox_bindings_copyleft_core.cpp
+++ b/src/cpp/gpytoolbox_bindings_copyleft_core.cpp
@@ -12,6 +12,7 @@ namespace py = pybind11;
 //forward declare all bindings
 void binding_swept_volume(py::module& m);
 void binding_booleans(py::module& m);
+void binding_tetrahedralize(py::module& m);
 
 
 PYBIND11_MODULE(gpytoolbox_bindings_copyleft, m) {
@@ -19,6 +20,7 @@ PYBIND11_MODULE(gpytoolbox_bindings_copyleft, m) {
     /// call all bindings declared above  
     binding_swept_volume(m);
     binding_booleans(m);
+    binding_tetrahedralize(m);
 
     m.def("help", [&]() {printf("hi"); });
 }

--- a/src/cpp/gpytoolbox_bindings_core.cpp
+++ b/src/cpp/gpytoolbox_bindings_core.cpp
@@ -27,6 +27,7 @@ void binding_upper_envelope(py::module& m);
 void binding_read_ply(py::module& m);
 void binding_write_ply(py::module& m);
 void binding_curved_hessian_intrinsic(py::module& m);
+void binding_triangulate(py::module& m);
 
 PYBIND11_MODULE(gpytoolbox_bindings, m) {
 
@@ -48,6 +49,7 @@ PYBIND11_MODULE(gpytoolbox_bindings, m) {
     binding_read_ply(m);
     binding_write_ply(m);
     binding_curved_hessian_intrinsic(m);
+    binding_triangulate(m);
 
     m.def("help", [&]() {printf("hi"); });
 }

--- a/src/gpytoolbox/__init__.py
+++ b/src/gpytoolbox/__init__.py
@@ -118,3 +118,4 @@ from .adjacency_matrix import adjacency_matrix
 from .non_manifold_edges import non_manifold_edges
 from .connected_components import connected_components
 from .rotation_matrix_from_vectors import rotation_matrix_from_vectors
+from .triangulate import triangulate

--- a/src/gpytoolbox/copyleft/__init__.py
+++ b/src/gpytoolbox/copyleft/__init__.py
@@ -2,3 +2,4 @@ from .mesh_boolean import mesh_boolean
 from .lazy_cage import lazy_cage
 from .do_meshes_intersect import do_meshes_intersect
 from .swept_volume import swept_volume
+from .tetrahedralize import tetrahedralize

--- a/src/gpytoolbox/copyleft/tetrahedralize.py
+++ b/src/gpytoolbox/copyleft/tetrahedralize.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+def tetrahedralize(V,F=None,
+    H=None,
+    max_volume=None,
+    min_rad_edge_ratio=None):
+    """Create a tetrahedralization of the input mesh in 3D.
+
+    This is a wrapper for libigl's Tetgen implementation.
+
+    Parameters
+    ----------
+    V : (n,3) numpy array
+        vertex list of points to mesh
+    F : (m,3) numpy int array, optional (default None)
+        face index list of a triangle.
+        If this is None, will simply mesh the convex hull of V.
+    H : (h,3) numpy array
+        list of seed points inside holes
+    max_volume: float, optional (default None)
+        If this is not None, the method will refine until this is the maximal
+        volume of any tet.
+    min_rad_edge_ratio : float, optional (default None)
+        If this is not None, the method will refine until this is the minimal
+        radius-edge ratio (in radians) of any tet. 
+        If this value is too aggressive, the method might silently fail to respect
+        the threshold, or hang forever.
+
+    Returns
+    -------
+    W : numpy double array
+        Matrix of mesh vertices
+    T : numpy int array
+        Matrix of tet indices
+    TF : numpy int array
+        Matrix of tet face indices
+
+    Notes
+    -----
+    In the future, we will hopefully use
+    "CDT - Constrained Delaunay Tetrahedrization made robust and practical" by
+    Diazzi et al. 2023.
+
+
+    Examples
+    --------
+    ```python
+    import gpytoolbox as gpy
+    # Mesh in V,F
+    W,T,TF = gpy.copyleft.tetrahedralize(V,F)
+    # Tet mesh in W,T,TF
+    ```
+    """
+
+    # Try to import C++ binding
+    try:
+        from gpytoolbox_bindings_copyleft import _tetrahedralize_cpp_impl
+    except:
+        raise ImportError("Gpytoolbox cannot import its C++ tetrahedralize binding.")
+
+    assert len(V.shape)==2 and V.shape[1]==3, "V must be a list of points in 3D."
+    assert max_volume is None or max_volume>0, "max_volume must be either None or a positive number."
+    if max_volume is None:
+        max_volume = -1.
+    assert min_rad_edge_ratio is None or min_rad_edge_ratio>=0, "max_angle must be either None or a nonnegative number."
+    if min_rad_edge_ratio is None:
+        min_rad_edge_ratio = -1.
+
+    if F is None:
+        F = np.array([], dtype=int)
+    if H is None:
+        H = np.array([], dtype=int)
+
+    status,W,T,TF = _tetrahedralize_cpp_impl(V.astype(np.float64),F.astype(np.int32),
+        H.astype(np.float64),
+        max_volume, min_rad_edge_ratio)
+    if status != 0:
+        raise RuntimeError("Tetgen failed.")
+
+    return W,T,TF

--- a/src/gpytoolbox/doublearea_intrinsic.py
+++ b/src/gpytoolbox/doublearea_intrinsic.py
@@ -39,6 +39,7 @@ def doublearea_intrinsic(l_sq,F):
     # Using Kahan's formula
     # https://people.eecs.berkeley.edu/~wkahan/Triangle.pdf
     a,b,c = l[:,0], l[:,1], l[:,2]
-    dblA = 0.5 * np.sqrt((a+(b+c)) * (c-(a-b)) * (c+(a-b)) * (a+(b-c)))
+    arg = (a+(b+c)) * (c-(a-b)) * (c+(a-b)) * (a+(b-c))
+    dblA = 0.5 * np.sqrt(np.maximum(arg, 0.))
 
     return dblA

--- a/src/gpytoolbox/triangulate.py
+++ b/src/gpytoolbox/triangulate.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+def triangulate(V,E=None,
+    max_area=None,
+    min_angle=None,
+    max_steiner_points=None):
+    """Create a conforming & constrained Delaunay triangulation of the input
+    curve in 2D.
+
+    This is a wrapper for the [CDT library](https://github.com/MarcoAttene/CDT).
+
+    Parameters
+    ----------
+    V : (n,2) numpy array
+        vertex list of points to mesh
+    E : (m,2) numpy int array, optional (default None)
+        edge index list of a polyline.
+        If this is None, will simply mesh the convex hull of V.
+    max_area: float, optional (default None)
+        If this is not None, the method will refine until this is the maximal
+        area of any triangle. 
+        NOTE: This curently does nothing.
+    min_angle : float, optional (default None)
+        If this is not None, the method will refine until this is the minimal
+        angle (in radians) of any triangle. 
+        If this value is too aggressive, the method might silently fail to respect
+        the threshold.
+        NOTE: This curently does nothing.
+    max_steiner_points : int, optional (default (6*n)**2)
+        how many points can be added during the refinement process to fulfill
+        max_area and min_angle
+        NOTE: This curently does nothing.
+
+    Returns
+    -------
+    W : numpy double array
+        Matrix of mesh vertices
+    F : numpy int array
+        Matrix of triangle indices
+
+    Notes
+    -----
+    max_area, min_angle, and max_steiner_points are not yet supported.
+    Once CDT adds support for them, add it to this function.
+
+
+    Examples
+    --------
+    ```python
+    import gpytoolbox as gpy
+    # Polyline in V,E
+    W,F = gpy.triangulate(V,E)
+    # New mesh in W,F
+    ```
+    """
+
+    # Try to import C++ binding
+    try:
+        from gpytoolbox_bindings import _triangulate_cpp_impl
+    except:
+        raise ImportError("Gpytoolbox cannot import its C++ triangulate binding.")
+
+    assert len(V.shape)==2 and V.shape[1]==2, "V must be a list of points in 2D."
+    assert max_area is None or max_area>0, "max_area must be either None or a positive number."
+    if max_area is None:
+        max_area = -1.
+    assert min_angle is None or min_angle>=0, "min_angle must be either None or a nonnegative number."
+    if min_angle is None:
+        min_angle = -1.
+    if max_steiner_points is None:
+        max_steiner_points = (6*V.shape[0])**2
+    assert max_steiner_points>=0
+
+    if E is None:
+        E = np.array([], dtype=int)
+
+    W,F = _triangulate_cpp_impl(V.astype(np.float64),E.astype(np.int32),
+        max_area, min_angle, max_steiner_points)
+
+    return W,F

--- a/test/test_tetrahedralize.py
+++ b/test/test_tetrahedralize.py
@@ -1,0 +1,58 @@
+from .context import gpytoolbox as gpy
+from .context import numpy as np
+from .context import unittest
+from scipy.stats import norm
+import os
+
+class TestTriangulate(unittest.TestCase):
+    def test_sphere(self):
+        V,F = gpy.icosphere(3)
+
+        W1,T,TF = gpy.copyleft.tetrahedralize(V,F)
+        self.assertTrue((np.linalg.norm(W1, axis=-1)<1.+1e-6).all())
+        self.assertTrue(W1.shape[0]>=V.shape[0])
+
+        W2,T,TF = gpy.copyleft.tetrahedralize(V,F, max_volume=0.001)
+        self.assertTrue((np.linalg.norm(W2, axis=-1)<1.+1e-6).all())
+        self.assertTrue(W2.shape[0]>=V.shape[0])
+        self.assertTrue(W2.shape[0]>W1.shape[0])
+
+        W3,T,TF = gpy.copyleft.tetrahedralize(V,F, min_rad_edge_ratio=0.2)
+        self.assertTrue((np.linalg.norm(W3, axis=-1)<1.+1e-6).all())
+        self.assertTrue(W3.shape[0]>=V.shape[0])
+        self.assertTrue(W3.shape[0]>W1.shape[0])
+
+        W4,T,TF = gpy.copyleft.tetrahedralize(V,F, min_rad_edge_ratio=0.2, max_volume=0.001)
+        self.assertTrue((np.linalg.norm(W4, axis=-1)<1.+1e-6).all())
+        self.assertTrue(W4.shape[0]>=V.shape[0])
+        self.assertTrue(W4.shape[0]>W1.shape[0])
+
+
+    def test_meshes(self):
+        meshes = ["bunny_oded.obj", "spot.obj"]
+        for mesh in meshes:
+            V,F = gpy.read_mesh("test/unit_tests_data/" + mesh)
+            V = gpy.normalize_points(V)
+
+            W1,T,TF = gpy.copyleft.tetrahedralize(V,F)
+            self.assertTrue((np.abs(W1)<0.5+1e-6).all())
+            self.assertTrue(W1.shape[0]>=V.shape[0])
+
+            W2,T,TF = gpy.copyleft.tetrahedralize(V,F, max_volume=0.001)
+            self.assertTrue((np.abs(W2)<0.5+1e-6).all())
+            self.assertTrue(W2.shape[0]>=V.shape[0])
+            self.assertTrue(W2.shape[0]>W1.shape[0])
+
+            W3,T,TF = gpy.copyleft.tetrahedralize(V,F, min_rad_edge_ratio=1.)
+            self.assertTrue((np.abs(W3)<0.5+1e-6).all())
+            self.assertTrue(W3.shape[0]>=V.shape[0])
+            self.assertTrue(W3.shape[0]>W1.shape[0])
+
+            W4,T,TF = gpy.copyleft.tetrahedralize(V,F, min_rad_edge_ratio=1., max_volume=0.001)
+            self.assertTrue((np.abs(W4)<0.5+1e-6).all())
+            self.assertTrue(W4.shape[0]>=V.shape[0])
+            self.assertTrue(W4.shape[0]>W1.shape[0])
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_triangulate.py
+++ b/test/test_triangulate.py
@@ -1,0 +1,81 @@
+from .context import gpytoolbox as gpy
+from .context import numpy as np
+from .context import unittest
+from scipy.stats import norm
+import os
+
+class TestTriangulate(unittest.TestCase):
+    def test_circle(self):
+        r = np.linspace(0, 2.*np.pi, num=100, endpoint=False)
+        V = np.stack((np.cos(r), np.sin(r)), axis=-1)
+        E = gpy.edge_indices(V.shape[0], closed=True)
+
+        def check(V,F,area=np.inf,angle=0):
+            self.assertTrue(len(gpy.non_manifold_edges(F))==0)
+            self.assertTrue((np.linalg.norm(V,axis=-1)<1.+1e-6).all())
+            self.assertTrue((gpy.doublearea(V,F)<2.*area+1e-6).all())
+            self.assertTrue((gpy.tip_angles(V,F)>angle-1e-6).all())
+
+        # Convex hull
+        W,F = gpy.triangulate(V)
+        check(W,F)
+
+        # Including edges
+        W,F = gpy.triangulate(V,E)
+        check(W,F)
+
+
+    def test_annulus(self):
+        r0 = np.linspace(0, 2.*np.pi, num=50, endpoint=False)
+        V0 = 0.5*np.stack((np.cos(r0), np.sin(r0)), axis=-1)
+        E0 = gpy.edge_indices(V0.shape[0], closed=True)
+        E0[:,[1,0]] = E0[:,[0,1]]
+        r1 = np.linspace(0, 2.*np.pi, num=100, endpoint=False)
+        V1 = np.stack((np.cos(r1), np.sin(r1)), axis=-1)
+        E1 = gpy.edge_indices(V1.shape[0], closed=True)
+        V = np.concatenate((V0,V1), axis=0)
+        E = np.concatenate((E0,E1+V0.shape[0]), axis=0)
+
+        # Convex hull
+        W,F = gpy.triangulate(V)
+        self.assertTrue((np.linalg.norm(W,axis=-1)<1.+1e-6).all())
+
+        def check(V,F,area=np.inf,angle=0):
+            self.assertTrue(len(gpy.non_manifold_edges(F))==0)
+            self.assertTrue((np.linalg.norm(V,axis=-1)<1.+1e-6).all()
+                and (np.linalg.norm(V,axis=-1)>0.5-1e-6).all())
+            self.assertTrue((gpy.doublearea(V,F)<2.*area+1e-6).all())
+            self.assertTrue((gpy.tip_angles(V,F)>angle-1e-6).all())
+
+        # Including edges
+        W,F = gpy.triangulate(V,E)
+        check(W,F)
+
+
+    def test_image(self):
+        filename = "test/unit_tests_data/illustrator.png"
+        V0 = gpy.png2poly(filename)[0][:-1]
+        E0 = gpy.edge_indices(V0.shape[0], closed=True)
+        E0[:,[1,0]] = E0[:,[0,1]]
+        V1 = gpy.png2poly(filename)[2][:-1]
+        E1 = gpy.edge_indices(V1.shape[0], closed=True)
+        V = gpy.normalize_points(np.concatenate((V0,V1), axis=0))
+        E = np.concatenate((E0,E1+V0.shape[0]), axis=0)
+
+        def check(V,F,area=np.inf,angle=0):
+            self.assertTrue(len(gpy.non_manifold_edges(F))==0)
+            self.assertTrue((np.abs(V)<1.+1e-6).all())
+            self.assertTrue((gpy.doublearea(V,F)<2.*area+1e-6).all())
+            self.assertTrue((gpy.tip_angles(V,F)>angle-1e-6).all())
+
+        # Convex hull
+        W,F = gpy.triangulate(V)
+        check(W,F)
+
+        # Including edges
+        W,F = gpy.triangulate(V,E)
+        check(W,F)
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds triangulation and tetrahedralization capacity.

For triangulation, this uses [CDT](https://github.com/artem-ogre/CDT). This is, in my opinion, better than Shewchuck's classic Triangle for 3 reasons:
- It has MPL2 licensing, like libigl, and unlike Triangle, which has a custom license that is very restrictive.
- It auto-detects holes, which you need to specify seed points to Triangle for.
- It is very robust.

For tetrahedralization, this uses TetGen through its libigl wrapper.

It's still not quite ready to merge before we discuss 2 important points:
- CDT does not yet support refinement (needed for min angle and max volume options). They seem to be actively working on it, and the library is so nice that I suggest we stick with it anyways. [This is the active PR](https://github.com/artem-ogre/CDT/pull/133). I tried it, and it works fine, but I do not want to use a non-merged PR for our library.
- TetGen is not just GPL (our normal copyleft), but AGPL, which adds an additional, more restrictive license to our copyleft module. I would have liked to used the new paper [CDT](https://github.com/MarcoAttene/CDT) (this has the same name as the 2D triangulation library...) for this, which seems to be a more modern TetGen, but their code does not support refinement of tet meshes, which is needed for quality and maximum volume options.
