### PR TITLE
Setting Numpy version to <2

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          python -m pip install numpy<2.0.0
+          python -m pip install numpy<=1.96.0
           python -m pip install scipy
           python -m pip install scikit-image
           sudo apt-get install \

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          python -m pip install numpy<2
+          python -m pip install numpy<2.0.0
           python -m pip install scipy
           python -m pip install scikit-image
           sudo apt-get install \

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          python -m pip install numpy
+          python -m pip install numpy<2
           python -m pip install scipy
           python -m pip install scikit-image
           sudo apt-get install \

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          python -m pip install numpy<=1.96.0
+          python -m pip install "numpy<=1.96.0"
           python -m pip install scipy
           python -m pip install scikit-image
           sudo apt-get install \

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install numpy<2
+          ${{ steps.installpython.outputs.python-path }} -m pip install numpy<2.0.0
           ${{ steps.installpython.outputs.python-path }} -m pip install scipy
           ${{ steps.installpython.outputs.python-path }} -m pip install scikit-image
 

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install numpy
+          ${{ steps.installpython.outputs.python-path }} -m pip install numpy<2
           ${{ steps.installpython.outputs.python-path }} -m pip install scipy
           ${{ steps.installpython.outputs.python-path }} -m pip install scikit-image
 

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install numpy<2.0.0
+          ${{ steps.installpython.outputs.python-path }} -m pip install numpy<=1.96.0
           ${{ steps.installpython.outputs.python-path }} -m pip install scipy
           ${{ steps.installpython.outputs.python-path }} -m pip install scikit-image
 

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install numpy<=1.96.0
+          ${{ steps.installpython.outputs.python-path }} -m pip install "numpy<=1.96.0"
           ${{ steps.installpython.outputs.python-path }} -m pip install scipy
           ${{ steps.installpython.outputs.python-path }} -m pip install scikit-image
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies (Windows)
         shell: bash -l {0}
         run: |
-          python -m pip install numpy<2.0.0
+          python -m pip install numpy<=1.96.0
           python -m pip install scipy
           python -m pip install scikit-image
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies (Windows)
         shell: bash -l {0}
         run: |
-          python -m pip install numpy<=1.96.0
+          python -m pip install "numpy<=1.96.0"
           python -m pip install scipy
           python -m pip install scikit-image
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies (Windows)
         shell: bash -l {0}
         run: |
-          python -m pip install numpy<2
+          python -m pip install numpy<2.0.0
           python -m pip install scipy
           python -m pip install scikit-image
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies (Windows)
         shell: bash -l {0}
         run: |
-          python -m pip install numpy
+          python -m pip install numpy<2
           python -m pip install scipy
           python -m pip install scikit-image
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-verbosity = "3"
 [build-system]
 requires = [
-    "numpy<2",
+    "numpy<=1.96.0",
     "scipy",
     "setuptools>=42",
     "wheel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-verbosity = "3"
 [build-system]
 requires = [
-    "numpy",
+    "numpy<2",
     "scipy",
     "setuptools>=42",
     "wheel",

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def main():
         license="MIT",
         package_dir={'': 'src'},
         packages=setuptools.find_packages(where="src"),
-        install_requires=['numpy', 'scipy', 'scikit-image'],
+        install_requires=['numpy<2', 'scipy', 'scikit-image'],
         ext_modules=[CMakeExtension('.', exclude_arch=exclude_arch)],
         setup_requires=['pybind11>=2.4'],
         cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
Numpy 2.0 came out, and it'll take a little bit to adapt our code to work with numpy 2.0. For now, this adds a hotfix to require numpy < 2