### PR TITLE
docs: fix halfedges call that includes vertices in args

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ library. We are thankful to them:
 - [Towaki Takikawa](https://github.com/tovacinni) ([PR #49](https://github.com/sgsellan/gpytoolbox/pull/49))
 - [Otman Benchekroun](https://github.com/otmanon) ([PR #59](https://github.com/sgsellan/gpytoolbox/pull/59))
 - [Abhishek Madan](https://github.com/abhimadan) ([PR #103](https://github.com/sgsellan/gpytoolbox/pull/103))
+- [Lukas Hermann](https://github.com/lsh) ([PR #135](https://github.com/sgsellan/gpytoolbox/pull/135))
 
 
 <!-- Most of the functionality in this library is python-only, and it requires no

--- a/src/gpytoolbox/halfedges.py
+++ b/src/gpytoolbox/halfedges.py
@@ -27,6 +27,7 @@ def halfedges(F):
     f = np.array([[0,1,2]],dtype=int)
     # Call to halfedges
     from gpytoolbox import halfedges
+    # (Thank you to Lukas Hermann for finding and fixing a typo in this next line)
     he = halfedges(f)
     ```
     

--- a/src/gpytoolbox/halfedges.py
+++ b/src/gpytoolbox/halfedges.py
@@ -27,7 +27,7 @@ def halfedges(F):
     f = np.array([[0,1,2]],dtype=int)
     # Call to halfedges
     from gpytoolbox import halfedges
-    he = halfedges(v,f)
+    he = halfedges(f)
     ```
     
     """


### PR DESCRIPTION
I noticed a tiny issue in the docs, where `halfedges` is fed `v`, but that method actually only takes `f`.