### PR TITLE
Resolve a Runtime Issue on Windows with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 
+# https://discourse.cmake.org/t/msvc-runtime-library-completely-ignored/10004
+cmake_policy(SET CMP0091 NEW)
+
 project(Bindings
 	DESCRIPTION
 		"Python bindings"
 )
+
+# MSVC needs explicit configuration for multithreading
+# Select a multi-threaded statically-linked runtime library
+# 	with or without debug information depending on the configuration
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ library. We are thankful to them:
 - [Otman Benchekroun](https://github.com/otmanon) ([PR #59](https://github.com/sgsellan/gpytoolbox/pull/59))
 - [Abhishek Madan](https://github.com/abhimadan) ([PR #103](https://github.com/sgsellan/gpytoolbox/pull/103))
 - [Lukas Hermann](https://github.com/lsh) ([PR #135](https://github.com/sgsellan/gpytoolbox/pull/135))
-
+- [Haoyang Wu](https://github.com/H-YWu) ([PR #142](https://github.com/sgsellan/gpytoolbox/pull/142))
 
 <!-- Most of the functionality in this library is python-only, and it requires no
 installation. To use it, simply clone this repository


### PR DESCRIPTION
## Bug

On Windows the library compiled with MSVC will suddenly exit without any warning message when calling `reach_for_the_arcs()`, and results cannot be generated. It turns out that the bug is caused by the `reset()` function of the struct `Profiler` in the `PoissonRecon` code, which uses `mutex`. However, we need explicit configuration in MSVC if we need a multi-threading runtime library.

## Changes

In _CMakeListst.txt_:
- Add static multi-threading runtime library configuration for MSVC to ensure the `PoissonRecon` code runs successfully.
- Set `CMP0091` policy to `NEW` to support `CMAKE_MSVC_RUNTIME_LIBRARY`.

## Testing

The changes were tested in the following environment:

- Operating System: Windows 11
- Compiler: MSVC 19.41.34117.0
- IDE: Visual Studio 17 2022
- Build Tool: CMake 3.27.7
- Package Manager: Conda 24.3.0

Based on the same changes to _CMakeListst.txt_ in https://github.com/H-YWu/reach-for-the-arcs-code/tree/windows-build:

> All Python scripts in the _scripts_ directory, except _fig_many-shapes-experiment.py_, were tested once (without `ndc`). There were several **Runtime Warnings** such as "MatrixRankWarning: Matrix is exactly singular" during the execution of some scripts, but results were generated successfully.

For https://github.com/H-YWu/gpytoolbox/tree/windows-build, I only tested _fig_adding-spheres.py_ with replacing calling from `rfta` package with my modified build of `gpytoolbox` package. The results were generated successfully.