### PR TITLE
Allow numpy 2.1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def main():
         license="MIT",
         package_dir={'': 'src'},
         packages=setuptools.find_packages(where="src"),
-        install_requires=['numpy<2', 'scipy', 'scikit-image', 'scs'],
+        install_requires=['numpy<2.2', 'scipy', 'scikit-image', 'scs'],
         ext_modules=[CMakeExtension('.', exclude_arch=exclude_arch)],
         setup_requires=['pybind11>=2.4'],
         cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
There is still a dependency constraint in setup.py that needs to be corrected.