### PR TITLE
Hausdorff distance fix

### DIFF
--- a/src/cpp/binding_decimate.cpp
+++ b/src/cpp/binding_decimate.cpp
@@ -30,16 +30,16 @@ void binding_decimate(py::module& m) {
     //         igl::decimate_post_collapse_callback post_collapse;
     // igl::decimate_trivial_callbacks(pre_collapse,post_collapse);
             if(method==0) {
-                std::cout << "Decimating with method 0" << std::endl;
-                igl::writeOBJ("decimate_input.obj",V,F);
-                std::cout << "Wrote input to decimate_input.obj" << std::endl;
-                std::cout << "Number of faces: " << num_faces << std::endl;
+                // std::cout << "Decimating with method 0" << std::endl;
+                // igl::writeOBJ("decimate_input.obj",V,F);
+                // std::cout << "Wrote input to decimate_input.obj" << std::endl;
+                // std::cout << "Number of faces: " << num_faces << std::endl;
                 igl::decimate(V,F,num_faces,
                     //This will be required when we bump the libigl version.
                     block_intersections,
                     SV,SF,I,J);
             } else if(method==1) {
-                std::cout << "Decimating with method 1" << std::endl;
+                // std::cout << "Decimating with method 1" << std::endl;
                 
                 igl::qslim(V,F,num_faces,
                     //This will be required when we bump the libigl version.

--- a/src/gpytoolbox/approximate_hausdorff_distance.py
+++ b/src/gpytoolbox/approximate_hausdorff_distance.py
@@ -4,14 +4,11 @@ from gpytoolbox.squared_distance_to_element import squared_distance_to_element
 
 def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
     """
-    Approximate the Hausdorff distance between two triangle meshes in 3D, i.e.
-    the maximum distance between any point on one mesh and the closest point
-    on the other mesh.
+    Approximate the Hausdorff distance between two triangle meshes in 3D, or polylines in 2D, i.e. the maximum distance between any point on one mesh and the closest point on the other mesh.
 
     d = max { d(pA,B), d(pB,A) }
     
-    where pA is a point on mesh A and pB is a point on mesh B, and d(pA,B) is
-    the distance between pA and the closest point on B. Our approximation will instead compute
+    where pA is a point on mesh/polyline A and pB is a point on mesh/polyline B, and d(pA,B) is the distance between pA and the closest point on B. Our approximation will instead compute
 
     d = max { d(vA,B), d(vB,A) }
 
@@ -19,16 +16,16 @@ def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
 
     Parameters
     ----------
-    v1 : (n1,3) array
+    v1 : (n1,dim) array
         Vertices of first mesh.
-    f1 : (m1,3) array
+    f1 : (m1,dim) array
         Faces of first mesh.
-    v2 : (n2,3) array
+    v2 : (n2,dim) array
         Vertices of second mesh.
-    f2 : (m2,3) array
+    f2 : (m2,dim) array
         Faces of second mesh.
     use_cpp : bool, optional (default: True)
-        Whether to use the C++ implementation of triangle_triangle_distance.
+        Whether to use the C++ implementation of triangle_triangle_distance (3D only).
     
     Returns
     -------
@@ -42,9 +39,31 @@ def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
     Examples
     --------
     ```python
-    # meshes in v,f and u,g
-    # Minimum distance value
-    d = gpytoolbox.minimum_distance(v,f,u,g)
+    # 2D
+    # segment [0→1] vs [0→2], Hausdorff distance = 1
+    v1 = np.array([[0.0, 0.0],
+                    [1.0, 0.0]])
+    e1 = np.array([[0, 1]])
+    v2 = np.array([[0.0, 0.0],
+                    [2.0, 0.0]])
+    e2 = np.array([[0, 1]])
+    d = gpytoolbox.approximate_hausdorff_distance(v1, e1, v2, e2)
+    disp(d) # 1.0
+    #
+    # 3D
+    # triangle vs same triangle shifted by (1,1) => distance = sqrt(2)
+    v1 = np.array([[0.0, 0.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0]])
+    e1 = np.array([[0, 1],
+                    [1, 2],
+                    [2, 0]])
+    shift = np.array([1.0, 1.0])
+    v2 = v1 + shift
+    e2 = e1.copy()
+    expected = np.linalg.norm(shift)
+    d = gpytoolbox.approximate_hausdorff_distance(v1, e1, v2, e2)
+    disp(d) # 1.4142135623730951
     ```
     """
 

--- a/src/gpytoolbox/approximate_hausdorff_distance.py
+++ b/src/gpytoolbox/approximate_hausdorff_distance.py
@@ -48,13 +48,15 @@ def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
     ```
     """
 
+    dim = v1.shape[1]
+
     # cpp implementation
-    if use_cpp:
+    if use_cpp and dim==3:
         try:
             from gpytoolbox_bindings import _hausdorff_distance_cpp_impl
         except:
             raise ImportError("Gpytoolbox cannot import its C++ fast winding number binding.") 
-        return _hausdorff_distance_cpp_impl(v1,f1,v2,f2)
+        return _hausdorff_distance_cpp_impl(v1.astype(np.float64),f1.astype(np.int32),v2.astype(np.float64),f2.astype(np.int32))
 
     # Let's start by computing the one-sided distance, i.e., max(d(vA,B)). We will do this with a loop, but with pre-computed trees for efficient queriying.
         
@@ -76,7 +78,7 @@ def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
             q2 = queue.pop()
             # print("-----------")
             # print("Queue length : {}".format(len(queue)))
-            # print("q1: ",q1)
+            # # print("q1: ",q1)
             # print("q2: ",q2)
             # print("CH1[q1,]: ",CH1[q1,:])
             # print("CH2[q2,]: ",CH2[q2,:])
@@ -85,20 +87,28 @@ def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
             if (is_leaf2):
                 # Compute distance between vi and triangle q2
                 d = np.sqrt(squared_distance_to_element(v1[i,:],v2,f2[tri_ind2[q2],:])[0])
+                # print("Inputs to squared_distance_to_element: ")
+                # print("v1[i,:]: {}".format(v1[i,:]))
+                # print("v2: {}".format(v2))
+                # print("f2[tri_ind2[q2],:]: {}".format(f2[tri_ind2[q2],:]))
+                # print("Distance to element: {}".format(d))
                 if d < current_best_guess_dviB:
                     current_best_guess_dviB = d
+                # print("Current best guess: {}".format(current_best_guess_dviB))
             else:
                 # Compute distance between vi and bounding box of q2
                 # Distance from vi to the bounding box of q2
                 d = point_to_box_distance(v1[i,:],C2[q2,:],W2[q2,:])
-                d_max = point_to_box_max_distance(v1[i,:],C2[q2,:],W2[q2,:])
-                # print(d_max)
-                # If d_max is smaller than the current best guess for HD, then we don't need to pursue this part of the tree
-                if ((d < current_best_guess_dviB) and (d_max > current_best_guess_hd)):
+                # d_max = point_to_box_max_distance(v1[i,:],C2[q2,:],W2[q2,:])
+                # print("Distance to bounding box: {}".format(d))
+                # print("Max distance to bounding box: {}".format(d_max))
+
+                if ((d < current_best_guess_dviB)):
                     # Add children to queue
                     queue.append(CH2[q2,0])
                     queue.append(CH2[q2,1])
         # We have computed d(vi,B). Does it change our guess for hausdorff?
+        # print("Current best guess: {}".format(current_best_guess_dviB))
         if current_best_guess_dviB > current_best_guess_hd:
             current_best_guess_hd = current_best_guess_dviB
 
@@ -122,9 +132,9 @@ def approximate_hausdorff_distance(v1,f1,v2,f2,use_cpp=True):
                 # Compute distance between vi and bounding box of q2
                 # Distance from vi to the bounding box of q2
                 d = point_to_box_distance(v2[i,:],C1[q2,:],W1[q2,:])
-                d_max = point_to_box_max_distance(v2[i,:],C1[q2,:],W1[q2,:])
+                # d_max = point_to_box_max_distance(v2[i,:],C1[q2,:],W1[q2,:])
                 # If d_max is smaller than the current best guess for HD, then we don't need to pursue this part of the tree
-                if (d < current_best_guess_dviA and d_max > current_best_guess_hd):
+                if (d < current_best_guess_dviA):
                     # Add children to queue
                     queue.append(CH1[q2,0])
                     queue.append(CH1[q2,1])
@@ -154,7 +164,8 @@ def point_to_box_max_distance(p,C,W):
         Maximum distance between point and box.
     """
     d = 0.0
-    for i in range(3):
+    dim = len(p)
+    for i in range(dim):
         if p[i] < C[i]:
             # Distance to oppoisite corner
             d += (p[i]-C[i]-0.5*W[i])**2
@@ -182,8 +193,9 @@ def point_to_box_distance(p,C,W):
     d : float
         Distance between point and box.
     """
+    dim = len(p)
     d = 0.0
-    for i in range(3):
+    for i in range(dim):
         if p[i] < C[i]-0.5*W[i]:
             d += (p[i]-C[i]+0.5*W[i])**2
         elif p[i] > C[i]+0.5*W[i]:

--- a/test/test_approximate_hausdorff_distance.py
+++ b/test/test_approximate_hausdorff_distance.py
@@ -3,6 +3,32 @@ from .context import gpytoolbox
 from .context import unittest
 
 class TestApproximateHausdorffDistance(unittest.TestCase):
+    def test_identical_mesh(self):
+        # base square mesh in 2D
+        V2d, F = gpytoolbox.regular_square_mesh(20)
+        # embed into 3D (z=0)
+        V = np.hstack([V2d, np.zeros((V2d.shape[0], 1))])
+        # identical triangular surface => zero distance in both backends
+        for use_cpp in (False, True):
+            d = gpytoolbox.approximate_hausdorff_distance(
+                V, F, V, F, use_cpp=use_cpp
+            )
+            self.assertAlmostEqual(d, 0.0, places=7)
+
+    def test_translated_mesh(self):
+        V2d, F = gpytoolbox.regular_square_mesh(20)
+        # embed into 3D (z=0)
+        V = np.hstack([V2d, np.zeros((V2d.shape[0], 1))])
+        # translate the surface by a 3D vector => distance = vector length
+        shift = np.array([-0.7, 2.5, 1.1])
+        U = V + shift
+        expected = np.linalg.norm(shift)
+        for use_cpp in (False, True):
+            d = gpytoolbox.approximate_hausdorff_distance(
+                V, F, U, F, use_cpp=use_cpp
+            )
+            self.assertAlmostEqual(d, expected, places=7)
+
     def test_bunny(self):
         V,F = gpytoolbox.read_mesh("test/unit_tests_data/bunny_oded.obj")
         # Normalize mesh
@@ -39,7 +65,70 @@ class TestApproximateHausdorffDistance(unittest.TestCase):
             self.assertTrue(np.isclose(dist1,dist2))
             self.assertTrue(np.isclose(dist1,r))
 
-    # It would be nice to have more principled tests here...
+    def test_identical_polylines(self):
+        # identical polyline => distance = 0
+        v = np.array([[0.0, 0.0],
+                      [1.0, 0.0],
+                      [1.0, 1.0]])
+        e = np.array([[0, 1],
+                      [1, 2]])
+        d = gpytoolbox.approximate_hausdorff_distance(v, e, v, e)
+        self.assertAlmostEqual(d, 0.0, places=7)
+
+    def test_reversed_polyline(self):
+        # reversed ordering of vertices/edges still zero distance
+        v1 = np.array([[0.0, 0.0],
+                       [1.0, 0.0],
+                       [2.0, 0.0]])
+        e1 = np.array([[0, 1],
+                       [1, 2]])
+        v2 = v1[::-1]       # reverse list of points
+        e2 = np.array([[2, 1],
+                       [1, 0]])
+        d = gpytoolbox.approximate_hausdorff_distance(v1, e1, v2, e2)
+        self.assertAlmostEqual(d, 0.0, places=7)
+
+    def test_line_segment_vs_longer_segment(self):
+        # segment [0→1] vs [0→2], Hausdorff distance = 1
+        v1 = np.array([[0.0, 0.0],
+                       [1.0, 0.0]])
+        e1 = np.array([[0, 1]])
+        v2 = np.array([[0.0, 0.0],
+                       [2.0, 0.0]])
+        e2 = np.array([[0, 1]])
+        d = gpytoolbox.approximate_hausdorff_distance(v1, e1, v2, e2)
+        self.assertAlmostEqual(d, 1.0, places=7)
+
+    def test_shifted_triangle(self):
+        # triangle vs same triangle shifted by (1,1) => distance = sqrt(2)
+        v1 = np.array([[0.0, 0.0],
+                       [1.0, 0.0],
+                       [0.0, 1.0]])
+        e1 = np.array([[0, 1],
+                       [1, 2],
+                       [2, 0]])
+        shift = np.array([1.0, 1.0])
+        v2 = v1 + shift
+        e2 = e1.copy()
+        expected = np.linalg.norm(shift)
+        d = gpytoolbox.approximate_hausdorff_distance(v1, e1, v2, e2)
+        self.assertAlmostEqual(d, expected, places=7)
+
+    def test_identical_circle(self):
+        # identical circle => distance = 0
+        V, E = gpytoolbox.regular_circle_polyline(50)
+        d = gpytoolbox.approximate_hausdorff_distance(V, E, V, E)
+        self.assertAlmostEqual(d, 0.0, places=7)
+
+    def test_translated_circle(self):
+        # translate circle by (dx,dy) => distance = sqrt(dx^2+dy^2)
+        V, E = gpytoolbox.regular_circle_polyline(50)
+        shift = np.array([0.3, -0.4])
+        U = V + shift
+        expected = np.linalg.norm(shift)
+        d = gpytoolbox.approximate_hausdorff_distance(V, E, U, E)
+        self.assertAlmostEqual(d, expected, places=7)
+
     
 
 if __name__ == '__main__':

--- a/test/test_reach_for_the_arcs.py
+++ b/test/test_reach_for_the_arcs.py
@@ -115,6 +115,13 @@ class TestReachForTheArcs(unittest.TestCase):
             U,G = gpy.reach_for_the_arcs(GV, sdf(GV), fine_tune_iters=3,
                 local_search_iters=3,
                 parallel=True, verbose=False)
+            
+            # debuggin
+            import polyscope as ps
+            ps.init()
+            ps.register_surface_mesh("original", v, f)
+            ps.register_surface_mesh("ours", U, G.astype(np.int32))
+            ps.show()
 
             sdf_rec = lambda x: gpy.signed_distance(x, U, G)[0]
             print(np.max(np.abs(sdf(GV)-sdf_rec(GV))))

--- a/test/test_reach_for_the_arcs.py
+++ b/test/test_reach_for_the_arcs.py
@@ -5,7 +5,7 @@ from .context import unittest
 
 class TestReachForTheArcs(unittest.TestCase):
     def test_beat_marching_cubes_low_res(self):
-        meshes = ["bunny_oded.obj", "armadillo.obj"]
+        meshes = ["R.npy", "bunny_oded.obj", "armadillo.obj"]
         for mesh in meshes:
             if mesh[-3:]=="obj":
                 v, f = gpy.read_mesh("test/unit_tests_data/" + mesh)
@@ -39,7 +39,7 @@ class TestReachForTheArcs(unittest.TestCase):
 
 
     def test_noop(self):
-        meshes = ["bunny_oded.obj", "armadillo.obj"]
+        meshes = ["R.npy", "bunny_oded.obj", "armadillo.obj"]
         for mesh in meshes:
             if mesh[-3:]=="obj":
                 v, f = gpy.read_mesh("test/unit_tests_data/" + mesh)
@@ -69,7 +69,7 @@ class TestReachForTheArcs(unittest.TestCase):
 
 
     def test_parallel_is_the_same(self):
-        meshes = ["bunny_oded.obj", "armadillo.obj"]
+        meshes = ["R.npy", "bunny_oded.obj", "armadillo.obj"]
         for mesh in meshes:
             if mesh[-3:]=="obj":
                 v, f = gpy.read_mesh("test/unit_tests_data/" + mesh)
@@ -103,7 +103,7 @@ class TestReachForTheArcs(unittest.TestCase):
 
 
     def test_simple_is_sdf_violated(self):
-        meshes = ["cube.obj", "hemisphere.obj"]
+        meshes = ["bunny_oded.obj", "armadillo.obj"]
         for mesh in meshes:
             n = 10
             v, f = gpy.read_mesh("test/unit_tests_data/" + mesh)
@@ -117,7 +117,7 @@ class TestReachForTheArcs(unittest.TestCase):
                 parallel=True, verbose=False)
 
             sdf_rec = lambda x: gpy.signed_distance(x, U, G)[0]
-            # print(np.max(np.abs(sdf(GV)-sdf_rec(GV))))
+            print(np.max(np.abs(sdf(GV)-sdf_rec(GV))))
             self.assertTrue(np.max(np.abs(sdf(GV)-sdf_rec(GV))) < 0.05)
 
 

--- a/test/test_reach_for_the_arcs.py
+++ b/test/test_reach_for_the_arcs.py
@@ -103,7 +103,7 @@ class TestReachForTheArcs(unittest.TestCase):
 
 
     def test_simple_is_sdf_violated(self):
-        meshes = ["bunny_oded.obj", "armadillo.obj"]
+        meshes = ["cube.obj", "hemisphere.obj"]
         for mesh in meshes:
             n = 10
             v, f = gpy.read_mesh("test/unit_tests_data/" + mesh)
@@ -115,13 +115,6 @@ class TestReachForTheArcs(unittest.TestCase):
             U,G = gpy.reach_for_the_arcs(GV, sdf(GV), fine_tune_iters=3,
                 local_search_iters=3,
                 parallel=True, verbose=False)
-            
-            # debuggin
-            import polyscope as ps
-            ps.init()
-            ps.register_surface_mesh("original", v, f)
-            ps.register_surface_mesh("ours", U, G.astype(np.int32))
-            ps.show()
 
             sdf_rec = lambda x: gpy.signed_distance(x, U, G)[0]
             print(np.max(np.abs(sdf(GV)-sdf_rec(GV))))

--- a/test/test_reach_for_the_arcs.py
+++ b/test/test_reach_for_the_arcs.py
@@ -117,7 +117,7 @@ class TestReachForTheArcs(unittest.TestCase):
                 parallel=True, verbose=False)
 
             sdf_rec = lambda x: gpy.signed_distance(x, U, G)[0]
-            print(np.max(np.abs(sdf(GV)-sdf_rec(GV))))
+            # print(np.max(np.abs(sdf(GV)-sdf_rec(GV))))
             self.assertTrue(np.max(np.abs(sdf(GV)-sdf_rec(GV))) < 0.05)
 
 


### PR DESCRIPTION
This PR adds 2D polyline functionality for Hausdorff distances, and includes it in the RFTA and RFTS unit tests. Also removes the fact that `decimate` was writing a mesh to memory as a leftover for debugging (we should have caught that!)