### PR TITLE
Fixing #143

### DIFF
--- a/src/cpp/upper_envelope.cpp
+++ b/src/cpp/upper_envelope.cpp
@@ -472,14 +472,26 @@ void upper_envelope(Eigen::MatrixXd & VT, Eigen::MatrixXi & FT,  Eigen::MatrixXd
     //std::cout << "DT:" << std::endl << DT << std::endl;
 
     //start = clock();
-    if (idxCFT + CFT.rows() > CFTarray.rows() && idxCFT + CFT.rows() > CFTarray.cols()) {
-        int r_CFTarray = CFTarray.rows();
-        CFTarray.conservativeResize(2*r_CFTarray, CFTarray.cols());
-	CFTarray.block(r_CFTarray, 0, r_CFTarray, CFTarray.cols()).setConstant(0);
-        int r_CLTarray = CLTarray.rows();
-	CLTarray.conservativeResize(2*r_CLTarray, CLTarray.cols());
-	CLTarray.block(r_CLTarray, 0, r_CLTarray, CLTarray.cols()).setConstant(false);
+    // if (idxCFT + CFT.rows() > CFTarray.rows() && idxCFT + CFT.rows() > CFTarray.cols()) {
+    //     int r_CFTarray = CFTarray.rows();
+    //     CFTarray.conservativeResize(2*r_CFTarray, CFTarray.cols());
+	// CFTarray.block(r_CFTarray, 0, r_CFTarray, CFTarray.cols()).setConstant(0);
+    //     int r_CLTarray = CLTarray.rows();
+	// CLTarray.conservativeResize(2*r_CLTarray, CLTarray.cols());
+	// CLTarray.block(r_CLTarray, 0, r_CLTarray, CLTarray.cols()).setConstant(false);
+    // }
+
+    // Compute how many rows we *really* need:
+    int needed = idxCFT + CFT.rows();
+    // Double until we have enough
+    while (needed > CFTarray.rows()) {
+        int old = CFTarray.rows();
+        CFTarray.conservativeResize(old*2, Eigen::NoChange);
+        CFTarray.block(old, 0, old, CFTarray.cols()).setConstant(0);
+        CLTarray.conservativeResize(old*2, Eigen::NoChange);
+        CLTarray.block(old, 0, old, CLTarray.cols()).setConstant(false);
     }
+    // Now it's safe:
 
     CFTarray.block(idxCFT, 0, CFT.rows(), CFT.cols()) = CFT;
     ArrayXb CLT(CFT.rows(), DT.cols());

--- a/test/test_upper_envelope.py
+++ b/test/test_upper_envelope.py
@@ -5,7 +5,7 @@ from .context import unittest
 # print("0")
 import tetgen
 
-# Would be nice to expand this... but this is a pretty good algorithm, how to validate it?
+# TO DO: Expand this.
 class TestUpperEnvelope(unittest.TestCase):
     def test_no_inversions(self):
         self.assertTrue(True)
@@ -31,6 +31,20 @@ class TestUpperEnvelope(unittest.TestCase):
             # print("7")
             # self.assertTrue that no tet is flipped:
             self.assertTrue(np.min(gpytoolbox.volume(u,g))>-1e-8)
+    def test_issue_143(self):
+        labels = 4
+        resolution = 4 # The issue said 5, but I needed to make it 4 to break it
+        v, t = gpytoolbox.regular_cube_mesh(resolution)
+        w = np.zeros((v.shape[0],labels))
+        for i in range(labels):
+            p = np.random.rand(3)
+            # print( "Center: ", p )
+            for j in range(v.shape[0]):
+                w[j,i] = -np.linalg.norm( v[j] - p )
+        
+        # This used to crash
+        u, g, l = gpytoolbox.upper_envelope(v,t,w)
+        # but it doesn't anymore
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes the bug in the memory allocation of `upper_envelope` in #143 . Instead of just allocating twice the size of the matrices that keep track of the tetrahedra (which fails if the required size is over twice the prior size), it resizes to the needed amount.