### PR TITLE
Document increment order in regular_cube_mesh

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          python -m pip install tetgen
+          python -m pip install "tetgen<0.7"
           python -m unittest -v
 
 # see https://github.com/libigl/libigl/blob/main/.github/workflows/continuous.yml

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install tetgen
+          ${{ steps.installpython.outputs.python-path }} -m pip install "tetgen<0.7"
           ${{ steps.installpython.outputs.python-path }} -m unittest -v
 
 # see https://github.com/libigl/libigl/blob/main/.github/workflows/continuous.yml

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          python -m pip install tetgen
+          python -m pip install "tetgen<0.7"
           python -m unittest -v
         # python -c "import gpytoolbox"
         # python -c "import gpytoolbox_bindings"

--- a/src/gpytoolbox/regular_cube_mesh.py
+++ b/src/gpytoolbox/regular_cube_mesh.py
@@ -26,6 +26,15 @@ def regular_cube_mesh(nx,
     T : (m,T) numpy int array
         tet index list of a tet mesh
 
+    Notes
+    -----
+    The dimensions are incremented in the grid in the following order: `z, x, y` (i.e., all `z` values are iterated over before incrementing `y`). Obtaining a meshgrid-style `(nx,ny,nz)` tensor for each coordinate dimension of `V` can be done as follows:
+    ```python
+    # Get the x coordinate of V from `regular_cube_mesh` in a (nx,ny,nz) tensor
+    Vx = V[:,0]
+    Vx_grid = Vx.reshape((ny,nx,nz)).transpose(1,0,2)
+    ```
+
     See Also
     --------
     regular_square_mesh.


### PR DESCRIPTION
Adds some documentation for `regular_cube_mesh` to clarify the increment order of the dimensions in `V`.