### PR TITLE
Build wheels for Python 3.14

### DIFF
--- a/.github/workflows/ciwheels.yml
+++ b/.github/workflows/ciwheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cpversion: ["cp310", "cp311", "cp312", "cp313"]
+        cpversion: ["cp310", "cp311", "cp312", "cp313", "cp314"]
         os: [ { runs-on: ubuntu-latest, cibw-arch: manylinux_x86_64}, { runs-on: macos-latest, cibw-arch: macosx_x86_64}, { runs-on: macos-latest, cibw-arch: macosx_arm64}, { runs-on: windows-latest, cibw-arch: win_amd64} ]
 
     name: Build wheels ${{ matrix.cpversion }}-${{ matrix.os.cibw-arch }}
@@ -46,7 +46,6 @@ jobs:
       # CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel-symbols --manylinux 2_28 {wheel} && auditwheel repair --plat manylinux_2_28_x86_64 -w {dest_dir} {wheel}"
       CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --plat manylinux_2_28_x86_64 -w {dest_dir} {wheel}"
       CIBW_MANYLINUX_X86_64_IMAGE: 'manylinux_2_28'
-      CIBW_PRERELEASE_PYTHONS: 1
       # # CIBW_BEFORE_BUILD_LINUX: "dnf install -y libXrandr libXrandr-devel libXinerama libXinerama-devel libXcursor libXcursor-devel libXi libXi-devel"
       # # CIBW_BEFORE_BUILD_LINUX: "apt-get update && apt-get install -y libxrandr2 libxrandr-dev libxinerama1 libxinerama-dev libxcursor1 libxcursor-dev libxi6 libxi-dev"
       # CIBW_BEFORE_BUILD_LINUX: "sed -i 's|http://deb.debian.org/debian|https://archive.debian.org/debian|g' /etc/apt/sources.list && sed -i 's|http://security.debian.org/debian-security|https://archive.debian.org/debian-security|g' /etc/apt/sources.list && apt-get update && apt-get install -y libxrandr2 libxrandr-dev libxinerama1 libxinerama-dev libxcursor1 libxcursor-dev libxi6 libxi-dev"
@@ -69,7 +68,7 @@ jobs:
           submodules: 'recursive'
       
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.4.1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          python -m pip install tetgen
+          python -m pip install "tetgen<0.7"
           python -m unittest -v
 
 # see https://github.com/libigl/libigl/blob/main/.github/workflows/continuous.yml

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install tetgen
+          ${{ steps.installpython.outputs.python-path }} -m pip install "tetgen<0.7"
           ${{ steps.installpython.outputs.python-path }} -m unittest -v
 
 # see https://github.com/libigl/libigl/blob/main/.github/workflows/continuous.yml

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          python -m pip install tetgen
+          python -m pip install "tetgen<0.7"
           python -m unittest -v
         # python -c "import gpytoolbox"
         # python -c "import gpytoolbox_bindings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 build-verbosity = "3"
 [build-system]
 requires = [
-    "numpy>=1.22.4,<2.4",
-    "scipy>=1.7,<=1.16.2",
+    "numpy>=1.22.4,<=2.4.6",
+    "scipy>=1.7,<=1.17.1",
     "setuptools>=42",
     "wheel",
     "cmake>=3.16,<3.27",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-verbosity = "3"
 [build-system]
 requires = [
-    "numpy>=1.22.4,<=2.3",
+    "numpy>=1.22.4,<2.4",
     "scipy>=1.7,<=1.16.2",
     "setuptools>=42",
     "wheel",

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def main():
         license="MIT",
         package_dir={'': 'src'},
         packages=setuptools.find_packages(where="src"),
-        install_requires=['numpy>=1.22.4,<2.3', 'scipy>=1.7,<=1.15', 'scikit-image', 'scs'],
+        install_requires=['numpy>=1.22.4,<=2.4.6', 'scipy>=1.7,<=1.17.1', 'scikit-image', 'scs'],
         ext_modules=[CMakeExtension('.', exclude_arch=exclude_arch)],
         setup_requires=['pybind11>=2.4'],
         cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
## Summary
- Add `cp314` to the wheel build matrix in `ciwheels.yml`.
- Bump `pypa/cibuildwheel` `v2.23.2` → `v3.4.1` (CPython 3.14 support starts in cibuildwheel 3.1; latest stable is 3.4.1).
- Remove `CIBW_PRERELEASE_PYTHONS`, which was **removed** in cibuildwheel 3.0 (folded into `enable`); 3.14 is a default target now.
- Relax numpy/scipy bounds in both `pyproject.toml` (build) and `setup.py` (runtime) to current latest — `numpy<=2.4.6`, `scipy<=1.17.1` — based on empirical testing (see below). pip still resolves the appropriate older versions for the `cp310` jobs since later numpy/scipy dropped 3.10.
- Pin `tetgen<0.7` in the three full-build workflows to fix an unrelated CI break (same fix as PR #176).

## Empirical evidence for relaxed bounds
Tested locally on Python 3.12 with the prebuilt `gpytoolbox==0.3.7` wheel from PyPI:

| numpy | scipy | result |
|---|---|---|
| 2.2.6 | 1.15.0 | OK (baseline, the previous bounds' max) |
| **2.4.6** | **1.17.1** | OK (**345 tests pass in 1049s**) |

Upper bounds can be loosened all the way to current latest without test regressions. PyPI wheel resolution verified for every Python in the matrix: cp310 → numpy 2.2.6 / scipy 1.15.3 (since later versions dropped 3.10); cp311–cp314 → numpy 2.4.6 / scipy 1.17.1.

## CI verification ✅
All four CI runs on the final commit (`ccf78c0`) pass:
- ✅ **Pip build** — all 20 wheel jobs green (cp310, cp311, cp312, cp313, **cp314** × manylinux_x86_64, macosx_x86_64, macosx_arm64, win_amd64)
- ✅ Full build (Linux)
- ✅ Full build (MacOS)
- ✅ Full build (Windows)

## Test plan
- [x] CI builds cp314 wheels for all four arches.
- [x] CI still builds cp310–cp313 wheels under the loosened build bounds.
- [x] Full-build (linux/macos/windows) test workflows pass with the `tetgen<0.7` pin.
- [x] Local test suite passes against latest numpy/scipy (Python 3.12, 345 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)