### PR TITLE
Fix shape flipping with align_rotations_with_velocity on curved paths (#136)

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          python -m pip install tetgen
+          python -m pip install "tetgen<0.7"
           python -m unittest -v
 
 # see https://github.com/libigl/libigl/blob/main/.github/workflows/continuous.yml

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          ${{ steps.installpython.outputs.python-path }} -m pip install tetgen
+          ${{ steps.installpython.outputs.python-path }} -m pip install "tetgen<0.7"
           ${{ steps.installpython.outputs.python-path }} -m unittest -v
 
 # see https://github.com/libigl/libigl/blob/main/.github/workflows/continuous.yml

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          python -m pip install tetgen
+          python -m pip install "tetgen<0.7"
           python -m unittest -v
         # python -c "import gpytoolbox"
         # python -c "import gpytoolbox_bindings"

--- a/src/gpytoolbox/copyleft/swept_volume.py
+++ b/src/gpytoolbox/copyleft/swept_volume.py
@@ -76,23 +76,19 @@ def swept_volume(V,F,transformations=None,rotations=None,translations=None,scale
     if(translations is not None):
         transformations = []
         num_transformations = len(translations)
+        translations = [np.asarray(t, dtype=np.float64) for t in translations]
+
+        velocity_rotations = None
+        if (rotations is None and align_rotations_with_velocity):
+            velocity_rotations = velocity_alignment_rotations(translations)
+
         for i in range(num_transformations):
             this_transformation = np.eye(4)
             this_transformation[0:3,3] = translations[i]
             if (rotations is not None):
                 this_transformation[0:3,0:3] = rotations[i]
-            elif (align_rotations_with_velocity):
-                vel_0 = np.array([1,0,0])
-                # Three cases
-                if i==0: # We are at the first point
-                    vel_1 = translations[1] - translations[0]
-                elif i==(num_transformations-1):
-                    vel_1 = translations[num_transformations-1] - translations[num_transformations-2]
-                else:
-                    vel_1 = translations[i+1] - translations[i-1]
-                vel_1 = vel_1/np.linalg.norm(vel_1)
-                rotation = rotation_matrix_from_vectors(vel_0, vel_1)
-                this_transformation[0:3,0:3] = rotation
+            elif (velocity_rotations is not None):
+                this_transformation[0:3,0:3] = velocity_rotations[i]
             if (scales is not None):
                 this_transformation[0:3,0:3] = scales[i]*this_transformation[0:3,0:3]
             transformations.append(this_transformation)
@@ -107,15 +103,52 @@ def swept_volume(V,F,transformations=None,rotations=None,translations=None,scale
     return v,f
 
 
+def velocity_alignment_rotations(translations):
+    # Build a rotation for each keyframe that aligns the shape's local x-axis
+    # with the (finite-difference) velocity along the trajectory.
+    #
+    # Rather than computing each rotation independently as the minimal rotation
+    # from a fixed global reference, we compose the minimal rotations *between
+    # consecutive velocities*. This propagates a consistent frame along the
+    # path (a discrete rotation-minimizing frame), avoiding the spurious roll
+    # about the velocity axis that otherwise makes the shape flip on curved
+    # paths such as spirals (see issue #136).
+    num = len(translations)
+    velocities = []
+    for i in range(num):
+        if i == 0:
+            vel = translations[1] - translations[0]
+        elif i == num - 1:
+            vel = translations[-1] - translations[-2]
+        else:
+            vel = translations[i + 1] - translations[i - 1]
+        velocities.append(vel / np.linalg.norm(vel))
+
+    reference = np.array([1.0, 0.0, 0.0])
+    rotations = [rotation_matrix_from_vectors(reference, velocities[0])]
+    for i in range(1, num):
+        delta = rotation_matrix_from_vectors(velocities[i - 1], velocities[i])
+        rotations.append(delta @ rotations[-1])
+    return rotations
+
+
 def rotation_matrix_from_vectors(vec1, vec2):
     # This function is due to Kevin R. on https://stackoverflow.com/questions/45142959/calculate-rotation-matrix-to-align-two-vectors-in-3d-space
     a, b = (vec1 / np.linalg.norm(vec1)).reshape(3), (vec2 / np.linalg.norm(vec2)).reshape(3)
     v = np.cross(a, b)
-    if any(v): #if not all zeros then 
-        c = np.dot(a, b)
-        s = np.linalg.norm(v)
+    s = np.linalg.norm(v)
+    c = np.dot(a, b)
+    if s > 1e-8: # vectors are not (anti)parallel
         kmat = np.array([[0, -v[2], v[1]], [v[2], 0, -v[0]], [-v[1], v[0], 0]])
         return np.eye(3) + kmat + kmat.dot(kmat) * ((1 - c) / (s ** 2))
-
+    elif c > 0:
+        return np.eye(3) # identical directions
     else:
-        return np.eye(3) #cross of all zeros only occurs on identical directions
+        # antiparallel directions: rotate 180 degrees about any axis
+        # perpendicular to a (the minimal rotation is undefined here)
+        axis = np.cross(a, np.array([1.0, 0.0, 0.0]))
+        if np.linalg.norm(axis) < 1e-8:
+            axis = np.cross(a, np.array([0.0, 1.0, 0.0]))
+        axis = axis / np.linalg.norm(axis)
+        kmat = np.array([[0, -axis[2], axis[1]], [axis[2], 0, -axis[0]], [-axis[1], axis[0], 0]])
+        return np.eye(3) + 2 * kmat.dot(kmat)

--- a/src/gpytoolbox/copyleft/swept_volume.py
+++ b/src/gpytoolbox/copyleft/swept_volume.py
@@ -105,14 +105,7 @@ def swept_volume(V,F,transformations=None,rotations=None,translations=None,scale
 
 def velocity_alignment_rotations(translations):
     # Build a rotation for each keyframe that aligns the shape's local x-axis
-    # with the (finite-difference) velocity along the trajectory.
-    #
-    # Rather than computing each rotation independently as the minimal rotation
-    # from a fixed global reference, we compose the minimal rotations *between
-    # consecutive velocities*. This propagates a consistent frame along the
-    # path (a discrete rotation-minimizing frame), avoiding the spurious roll
-    # about the velocity axis that otherwise makes the shape flip on curved
-    # paths such as spirals (see issue #136).
+    # with the (finite-difference) velocity along the trajectory (see issue #136).
     num = len(translations)
     velocities = []
     for i in range(num):

--- a/test/test_swept_volume.py
+++ b/test/test_swept_volume.py
@@ -2,6 +2,7 @@ from .context import gpytoolbox
 from .context import numpy as np
 from .context import unittest
 from gpytoolbox.copyleft import swept_volume
+from gpytoolbox.copyleft.swept_volume import velocity_alignment_rotations
 # import polyscope as ps
 # import igl
 
@@ -44,6 +45,49 @@ class TestSweptVolume(unittest.TestCase):
         # ps.init()
         # ps.register_surface_mesh("test_sv",u,g)
         # ps.show()
+
+    def test_velocity_alignment_on_spiral(self):
+        # Regression test for issue #136: on a spiral path, aligning rotations
+        # with velocity used to introduce a spurious roll about the velocity
+        # axis (computed each keyframe from a fixed global reference), making
+        # the shape flip on one side of the helix. The rotation-minimizing
+        # frame should instead produce proper rotations whose local x-axis
+        # tracks the velocity and which vary smoothly (no sudden flips).
+        radius, start_y, end_y, num_steps, pitch = 0.025, -0.07, 0.07, 50, 0.2
+        h_step = (end_y - start_y) / num_steps
+        translations = []
+        for i in range(num_steps):
+            theta = 2 * np.pi * i / (num_steps * pitch)
+            translations.append(np.array([radius * np.cos(theta),
+                                          start_y + i * h_step,
+                                          radius * np.sin(theta)]))
+
+        rotations = velocity_alignment_rotations(translations)
+        self.assertEqual(len(rotations), num_steps)
+
+        velocities = []
+        for i in range(num_steps):
+            if i == 0:
+                vel = translations[1] - translations[0]
+            elif i == num_steps - 1:
+                vel = translations[-1] - translations[-2]
+            else:
+                vel = translations[i + 1] - translations[i - 1]
+            velocities.append(vel / np.linalg.norm(vel))
+
+        x_axis = np.array([1.0, 0.0, 0.0])
+        for R, vel in zip(rotations, velocities):
+            # proper rotation
+            self.assertTrue(np.allclose(R @ R.T, np.eye(3), atol=1e-8))
+            self.assertTrue(np.isclose(np.linalg.det(R), 1.0, atol=1e-8))
+            # local x-axis aligns with the velocity
+            self.assertTrue(np.allclose(R @ x_axis, vel, atol=1e-7))
+
+        # frame must vary smoothly: no near-180-degree flip between neighbours
+        up = np.array([0.0, 1.0, 0.0])
+        max_up_jump = max(np.linalg.norm(rotations[i] @ up - rotations[i - 1] @ up)
+                          for i in range(1, num_steps))
+        self.assertLess(max_up_jump, 1.0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_swept_volume.py
+++ b/test/test_swept_volume.py
@@ -91,3 +91,4 @@ class TestSweptVolume(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    


### PR DESCRIPTION
## Summary

Fixes #136. When `align_rotations_with_velocity=True`, swept volumes along curved paths such as a spiral came out wrong on one side of the helix while looking correct on the other.

**Root cause:** each keyframe's rotation was computed *independently* as the minimal rotation from a fixed global reference (`[1,0,0]`) to that keyframe's velocity. The minimal rotation pins down the *forward* axis but leaves the *roll* about that axis determined arbitrarily by the global reference. On a spiral the velocity direction sweeps around a cone, so this spurious roll cancels on one side of the helix and accumulates (up to a ~180° flip) on the other — exactly the "one side normal, one side wrong" symptom in the issue.

## Changes

- Add `velocity_alignment_rotations`, which builds a **discrete rotation-minimizing frame** by composing the minimal rotations *between consecutive velocities* rather than recomputing each from a fixed global reference. This propagates a consistent frame along the path, so the shape no longer flips.
- Fix the antiparallel singularity in `rotation_matrix_from_vectors`: it previously returned the identity when the two vectors were antiparallel (cross product all zeros) instead of a proper 180° rotation.
- Add a regression test (`test_velocity_alignment_on_spiral`) reproducing the issue's spiral and asserting the per-keyframe rotations are proper rotations, that the local x-axis tracks the velocity, and that the frame varies smoothly (no near-180° flip between neighbours).
- CI: pin `tetgen<0.7` in the unit-test workflows so they pass (same fix as #174).

## Verification

Built the C++ bindings locally (`cmake` + `make`, both `gpytoolbox_bindings` and `gpytoolbox_bindings_copyleft`) and ran the suite against them:

```
python -m unittest test.test_swept_volume -v
test_cube ... ok
test_velocity_alignment_on_spiral ... ok
test_with_scale ... ok
Ran 3 tests — OK
```

End-to-end on the issue's helical path with `align_rotations_with_velocity=True`, the C++ `swept_volume` now produces a valid closed manifold (Euler characteristic = 2), with no flipped/self-intersecting side.

Rotation-logic checks on the issue's exact spiral (pure NumPy, independent of the binding):

- every rotation is orthonormal with `det = 1`
- `R @ [1,0,0]` equals the velocity at each keyframe
- max up-vector jump between consecutive frames: **OLD 1.73** (a near-180° flip) → **NEW 0.61** (smooth)
- antiparallel case now maps `[1,0,0] -> [-1,0,0]` with `det = 1`

## Test plan

- [x] Build the bindings and run `test/test_swept_volume.py` — all 3 tests pass
- [x] Re-run the issue's spiral with `align_rotations_with_velocity=True` and confirm a valid closed mesh with no flipped side
- [x] CI green across all workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
