### PR TITLE
Make Embree optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ option(LIBIGL_EMBREE "Build target igl::embree" ON)
 set(BOOST_ROOT "/Users/silviasellan/Dropbox/temp/libigl/build/_deps/boost-src")
 include(libigl)
 igl_include(glfw)
-igl_include(embree)
+if(LIBIGL_EMBREE)
+	igl_include(embree)
+endif()
 
 # Include PoissonRecon
 include(PoissonRecon)
@@ -61,7 +63,10 @@ else()
 endif()
 
 # List of all libraries to link
-set(LIBRARIES_TO_LINK igl::core igl::embree nanoflann PoissonRecon ${GL_LIBS})
+set(LIBRARIES_TO_LINK igl::core nanoflann PoissonRecon ${GL_LIBS})
+if(LIBIGL_EMBREE)
+	list(APPEND LIBRARIES_TO_LINK igl::embree)
+endif()
 set(COPYLEFT_LIBRARIES_TO_LINK igl::core igl_copyleft::cgal)
 
 add_library(cpytoolbox
@@ -69,7 +74,6 @@ add_library(cpytoolbox
 	# SHARED
 	# Headers
 	src/cpp/upper_envelope.h
-	src/cpp/ray_mesh_intersect_aabb.h
 	src/cpp/particle_swarm.h
 	src/cpp/in_element_aabb.h
 	src/cpp/read_obj.h
@@ -95,7 +99,6 @@ add_library(cpytoolbox
 	src/cpp/dual_contouring_of_signed_distance_data/vertex_refinement.h
 	# Source
 	src/cpp/upper_envelope.cpp
-	src/cpp/ray_mesh_intersect_aabb.cpp
 	src/cpp/particle_swarm.cpp
 	src/cpp/in_element_aabb.cpp
 	src/cpp/read_obj.cpp
@@ -124,6 +127,13 @@ add_library(cpytoolbox
 	# tinyply
 	src/cpp/tinyply/tinyply.h
 	)
+
+if(LIBIGL_EMBREE)
+	target_sources(cpytoolbox PRIVATE
+		src/cpp/ray_mesh_intersect_aabb.h
+		src/cpp/ray_mesh_intersect_aabb.cpp
+	)
+endif()
 
 	add_library(cpytoolbox_copyleft
 	STATIC
@@ -168,8 +178,6 @@ pybind11_add_module(gpytoolbox_bindings
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_marching_cubes.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_offset_surface.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_point_mesh_squared_distance.cpp"
-	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_ray_mesh_intersect.cpp"
-	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_ray_mesh_intersector.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_particle_swarm.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_read_stl.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_write_stl.cpp"
@@ -184,6 +192,14 @@ pybind11_add_module(gpytoolbox_bindings
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/reach_for_the_arcs//binding_fine_tune_point_cloud_iter.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/dual_contouring_of_signed_distance_data/binding_dcsdd.cpp"
 )
+
+if(LIBIGL_EMBREE)
+	target_sources(gpytoolbox_bindings PRIVATE
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_ray_mesh_intersect.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/binding_ray_mesh_intersector.cpp"
+	)
+	target_compile_definitions(gpytoolbox_bindings PRIVATE GPYTOOLBOX_WITH_EMBREE)
+endif()
 
 pybind11_add_module(gpytoolbox_bindings_copyleft
     "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/gpytoolbox_bindings_copyleft_core.cpp"
@@ -222,4 +238,3 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 		VERBATIM
 	)
 endif()
-

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import platform
+import shlex
 import subprocess
 import setuptools
 from setuptools import setup, Extension
@@ -42,7 +43,8 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+        cmake_args = shlex.split(os.environ.get('CMAKE_ARGS', ''))
+        cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
 
         # This is horrible, I don't know other way of installing dependencies on the wheel dependencies

--- a/src/cpp/gpytoolbox_bindings_core.cpp
+++ b/src/cpp/gpytoolbox_bindings_core.cpp
@@ -21,8 +21,10 @@ void binding_in_element_aabb(py::module& m);
 void binding_marching_cubes(py::module& m);
 void binding_offset_surface(py::module& m);
 void binding_point_mesh_squared_distance(py::module& m);
+#ifdef GPYTOOLBOX_WITH_EMBREE
 void binding_ray_mesh_intersect(py::module& m);
 void binding_ray_mesh_intersector(py::module& m);
+#endif
 void binding_particle_swarm(py::module& m);
 void binding_read_stl(py::module& m);
 void binding_write_stl(py::module& m);
@@ -52,8 +54,13 @@ PYBIND11_MODULE(gpytoolbox_bindings, m) {
     binding_marching_cubes(m);
     binding_offset_surface(m);
     binding_point_mesh_squared_distance(m);
+#ifdef GPYTOOLBOX_WITH_EMBREE
     binding_ray_mesh_intersect(m);
     binding_ray_mesh_intersector(m);
+    m.attr("_has_embree") = true;
+#else
+    m.attr("_has_embree") = false;
+#endif
     binding_particle_swarm(m);
     binding_read_stl(m);
     binding_write_stl(m);
@@ -70,4 +77,3 @@ PYBIND11_MODULE(gpytoolbox_bindings, m) {
 
     m.def("help", [&]() {printf("hi"); });
 }
-

--- a/src/gpytoolbox/ray_mesh_intersect.py
+++ b/src/gpytoolbox/ray_mesh_intersect.py
@@ -75,10 +75,11 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
     tri_ind : numpy int array, optional (default None)
         Vector of AABB element indices (-1 if *not* leaf node). If None and use_embree=False, will be computed
     intersector : gpytoolbox.ray_mesh_intersect_precompute, optional (default None)
-        Precomputed Embree intersector built via `gpytoolbox.ray_mesh_intersect_precompute(V, F)`.
-        When provided (and `use_embree=True`), reuses the persistent Embree scene
-        across calls instead of rebuilding it. V and F are still consulted only
-        for shape; the actual queries go through the cached intersector.
+        Precomputed intersector built via
+        `gpytoolbox.ray_mesh_intersect_precompute(V, F)`. When provided (and
+        `use_embree=True`), reuses the available Embree scene or portable AABB
+        tree across calls instead of rebuilding it. V and F are still consulted
+        only for shape; the actual queries go through the cached intersector.
 
     Returns
     -------
@@ -91,7 +92,8 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
 
     Examples
     --------
-    Standard one-shot call (rebuilds the Embree scene internally each time):
+    Standard one-shot call (rebuilds the available acceleration structure
+    internally each time):
     ```python
     from gpytoolbox import ray_mesh_intersect
     v,f = gpytoolbox.read_mesh("test/unit_tests_data/cube.obj")
@@ -100,9 +102,9 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
     t, ids, l = ray_mesh_intersect(cam_pos,cam_dir,v,f)
     ```
 
-    When making many calls against the same mesh, build the Embree
-    intersector once and reuse it via the `intersector=` kwarg to avoid
-    the O(n) construction cost on every call:
+    When making many calls against the same mesh, build the intersector once
+    and reuse it via the `intersector=` kwarg to avoid the O(n) construction
+    cost on every call:
     ```python
     v,f = gpytoolbox.read_mesh("bunny.obj")
     rmi = gpytoolbox.ray_mesh_intersect_precompute(v, f) # build once
@@ -113,11 +115,11 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
     ```
     """
     if use_embree:
-        import gpytoolbox_bindings
-        if getattr(gpytoolbox_bindings, "_has_embree", True):
-            if intersector is not None:
-                ts, ids, lambdas = intersector.intersect(cam_pos, cam_dir)
-            else:
+        if intersector is not None:
+            ts, ids, lambdas = intersector.intersect(cam_pos, cam_dir)
+        else:
+            import gpytoolbox_bindings
+            if getattr(gpytoolbox_bindings, "_has_embree", True):
                 ts, ids, lambdas = (
                     gpytoolbox_bindings._ray_mesh_intersect_cpp_impl(
                         cam_pos.astype(np.float64),
@@ -126,8 +128,8 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
                         F.astype(np.int32),
                     )
                 )
-        else:
-            use_embree = False
+            else:
+                use_embree = False
     if not use_embree:
         ts = np.inf*np.ones(cam_pos.shape[0])
         ids = -np.ones(cam_pos.shape[0],dtype=int)

--- a/src/gpytoolbox/ray_mesh_intersect.py
+++ b/src/gpytoolbox/ray_mesh_intersect.py
@@ -63,7 +63,9 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
     F : (m,3) numpy int array
         face index list of a triangle mesh
     use_embree : bool, optional (default True)
-        Whether to use the much more optimzed C++ AABB embree implementation of ray mesh intersections. If False, uses gpytoolbox's native AABB tree and gpytoolbox's intersection queries.
+        Whether to use the optimized C++ Embree implementation of ray-mesh
+        intersections. If False, or if GPyToolbox was built without Embree,
+        uses GPyToolbox's native AABB tree and intersection queries.
     C : numpy double array, optional (default None)
         Matrix of AABB box centers (if None and use_embree=False, will be computed)
     W : numpy double array, optional (default None)
@@ -111,16 +113,22 @@ def ray_mesh_intersect(cam_pos,cam_dir,V,F,use_embree=True,C=None,W=None,CH=None
     ```
     """
     if use_embree:
-        if intersector is not None:
-            ts, ids, lambdas = intersector.intersect(cam_pos, cam_dir)
+        import gpytoolbox_bindings
+        if getattr(gpytoolbox_bindings, "_has_embree", True):
+            if intersector is not None:
+                ts, ids, lambdas = intersector.intersect(cam_pos, cam_dir)
+            else:
+                ts, ids, lambdas = (
+                    gpytoolbox_bindings._ray_mesh_intersect_cpp_impl(
+                        cam_pos.astype(np.float64),
+                        cam_dir.astype(np.float64),
+                        V.astype(np.float64),
+                        F.astype(np.int32),
+                    )
+                )
         else:
-            try:
-                from gpytoolbox_bindings import _ray_mesh_intersect_cpp_impl
-            except:
-                raise ImportError("Gpytoolbox cannot import its C++ ray_mesh_intersect binding.")
-
-            ts, ids, lambdas = _ray_mesh_intersect_cpp_impl(cam_pos.astype(np.float64),cam_dir.astype(np.float64),V.astype(np.float64),F.astype(np.int32))
-    else:
+            use_embree = False
+    if not use_embree:
         ts = np.inf*np.ones(cam_pos.shape[0])
         ids = -np.ones(cam_pos.shape[0],dtype=int)
         lambdas = np.zeros((cam_pos.shape[0],3))

--- a/src/gpytoolbox/ray_mesh_intersect_precompute.py
+++ b/src/gpytoolbox/ray_mesh_intersect_precompute.py
@@ -2,11 +2,12 @@ import numpy as np
 
 
 class ray_mesh_intersect_precompute:
-    """Precomputed Embree intersector for repeated ray-mesh queries.
+    """Precomputed intersector for repeated ray-mesh queries.
 
-    Wraps libigl's `igl::embree::EmbreeIntersector` so the Embree scene is
-    built once and reused across many `ray_mesh_intersect` calls, avoiding
-    the per-call construction cost.
+    Uses libigl's `igl::embree::EmbreeIntersector` when GPyToolbox was built
+    with Embree. Otherwise, it builds and reuses GPyToolbox's portable AABB
+    tree. Both backends avoid rebuilding their acceleration structure on
+    every `ray_mesh_intersect` call.
 
     Parameters
     ----------
@@ -38,21 +39,24 @@ class ray_mesh_intersect_precompute:
     """
 
     def __init__(self, V, F):
-        try:
-            from gpytoolbox_bindings import _RayMeshIntersector_cpp_impl
-        except ImportError:
-            raise ImportError(
-                "Gpytoolbox cannot import its C++ ray_mesh_intersect_precompute "
-                "binding. The package may have been built without Embree.")
-
         V = np.ascontiguousarray(V, dtype=np.float64)
         F = np.ascontiguousarray(F, dtype=np.int32)
         if V.shape[1] != 3 or F.shape[1] != 3:
             raise ValueError("ray_mesh_intersect_precompute requires a 3D triangle mesh.")
 
+        import gpytoolbox_bindings
+        self._impl = None
+        self._aabb = None
+        if getattr(gpytoolbox_bindings, "_has_embree", True):
+            from gpytoolbox_bindings import _RayMeshIntersector_cpp_impl
+            self._impl = _RayMeshIntersector_cpp_impl(V, F)
+        else:
+            from gpytoolbox.initialize_aabbtree import initialize_aabbtree
+            C, W, CH, _, _, tri_ind, _ = initialize_aabbtree(V, F=F)
+            self._aabb = (C, W, CH, tri_ind)
+
         self._V = V
         self._F = F
-        self._impl = _RayMeshIntersector_cpp_impl(V, F)
 
     @property
     def V(self):
@@ -84,4 +88,11 @@ class ray_mesh_intersect_precompute:
         origins = np.ascontiguousarray(np.atleast_2d(origins), dtype=np.float64)
         directions = np.ascontiguousarray(np.atleast_2d(directions),
                                           dtype=np.float64)
-        return self._impl.intersect(origins, directions)
+        if self._impl is not None:
+            return self._impl.intersect(origins, directions)
+
+        from gpytoolbox.ray_mesh_intersect import ray_mesh_intersect
+        C, W, CH, tri_ind = self._aabb
+        return ray_mesh_intersect(
+            origins, directions, self._V, self._F, use_embree=False,
+            C=C, W=W, CH=CH, tri_ind=tri_ind)

--- a/src/gpytoolbox/ray_mesh_intersect_precompute.py
+++ b/src/gpytoolbox/ray_mesh_intersect_precompute.py
@@ -42,7 +42,8 @@ class ray_mesh_intersect_precompute:
             from gpytoolbox_bindings import _RayMeshIntersector_cpp_impl
         except ImportError:
             raise ImportError(
-                "Gpytoolbox cannot import its C++ ray_mesh_intersect_precompute binding.")
+                "Gpytoolbox cannot import its C++ ray_mesh_intersect_precompute "
+                "binding. The package may have been built without Embree.")
 
         V = np.ascontiguousarray(V, dtype=np.float64)
         F = np.ascontiguousarray(F, dtype=np.int32)

--- a/test/test_matryoshka.py
+++ b/test/test_matryoshka.py
@@ -2,6 +2,8 @@ from .context import numpy as np
 from .context import unittest
 from .context import gpytoolbox as gpy
 from gpytoolbox.matryoshka import _feasible, _transform_points, _sample_B_surface
+import gpytoolbox_bindings
+from unittest import mock
 
 
 def _unit_cube():
@@ -49,6 +51,15 @@ class TestMatryoshka(unittest.TestCase):
                              n_samples=300, seed=0)
         self.assertGreater(res['s'], 0.95)
         self.assertTrue(_verify_feasible(V, F, res))
+
+    def test_cube_scale_only_without_embree(self):
+        # matryoshka should reuse the portable cached intersector when Embree
+        # is unavailable rather than losing the whole public operation.
+        V, F = _unit_cube()
+        with mock.patch.object(gpytoolbox_bindings, "_has_embree", False):
+            res = gpy.matryoshka(V, F, optimize='scale_only',
+                                 n_samples=50, seed=0)
+        self.assertGreater(res['s'], 0.95)
 
     def test_sphere_rigid(self):
         # With rigid (scale + rotation + centroid) optimization, the sphere

--- a/test/test_ray_mesh_intersect.py
+++ b/test/test_ray_mesh_intersect.py
@@ -2,8 +2,23 @@ from .context import gpytoolbox
 from .context import numpy as np
 from .context import unittest
 import time
+from unittest import mock
 
 class TestRayMeshIntersect(unittest.TestCase):
+    def test_default_falls_back_without_embree(self):
+        import gpytoolbox_bindings
+
+        v, f = gpytoolbox.read_mesh("test/unit_tests_data/cube.obj")
+        cam_pos = np.array([[1, 0.1, 0.1], [1, 0.2, 0.0]])
+        cam_dir = np.array([[-1, 0, 0], [-1, 0, 0]])
+        with mock.patch.object(gpytoolbox_bindings, "_has_embree", False):
+            fallback = gpytoolbox.ray_mesh_intersect(cam_pos, cam_dir, v, f)
+        portable = gpytoolbox.ray_mesh_intersect(
+            cam_pos, cam_dir, v, f, use_embree=False)
+
+        for actual, expected in zip(fallback, portable):
+            np.testing.assert_allclose(actual, expected)
+
     def test_simple_cube(self):
         # This is a cube, centered at the origin, with side length 1
         v,f = gpytoolbox.read_mesh("test/unit_tests_data/cube.obj")

--- a/test/test_ray_mesh_intersect.py
+++ b/test/test_ray_mesh_intersect.py
@@ -20,11 +20,19 @@ class TestRayMeshIntersect(unittest.TestCase):
         for actual, expected in zip(fallback, portable):
             np.testing.assert_allclose(actual, expected)
 
-    @unittest.skipIf(_HAS_EMBREE, "requires a build without Embree")
-    def test_precompute_reports_missing_embree(self):
+    def test_precompute_falls_back_without_embree(self):
         v, f = gpytoolbox.read_mesh("test/unit_tests_data/cube.obj")
-        with self.assertRaisesRegex(ImportError, "built without Embree"):
-            gpytoolbox.ray_mesh_intersect_precompute(v, f)
+        cam_pos = np.array([[1, 0.1, 0.1], [1, 0.2, 0.0]])
+        cam_dir = np.array([[-1, 0, 0], [-1, 0, 0]])
+        with mock.patch.object(gpytoolbox_bindings, "_has_embree", False):
+            intersector = gpytoolbox.ray_mesh_intersect_precompute(v, f)
+            actual = gpytoolbox.ray_mesh_intersect(
+                cam_pos, cam_dir, v, f, intersector=intersector)
+        expected = gpytoolbox.ray_mesh_intersect(
+            cam_pos, cam_dir, v, f, use_embree=False)
+
+        for cached, uncached in zip(actual, expected):
+            np.testing.assert_allclose(cached, uncached)
 
     def test_simple_cube(self):
         # This is a cube, centered at the origin, with side length 1


### PR DESCRIPTION
## Summary

Honor the existing `LIBIGL_EMBREE` CMake option throughout the build.

When it is disabled, the build now:

- omits the Embree-specific libigl target, sources, and Python bindings;
- exposes `gpytoolbox_bindings._has_embree = False`;
- lets the ordinary `ray_mesh_intersect(...)` API use the existing portable AABB implementation;
- makes `ray_mesh_intersect_precompute(...)` cache that portable AABB tree, so repeated queries and internal users such as `matryoshka` remain functional; and
- forwards `CMAKE_ARGS` through setuptools so package builders can select `-DLIBIGL_EMBREE=OFF`.

## Why

`LIBIGL_EMBREE` already exists and defaults to `ON`, but the build previously included and linked Embree unconditionally. Embree is not available on every architecture supported by the rest of the dependency stack, notably Linux PPC64LE, while GPyToolbox already contains a portable ray/mesh intersection implementation.

After syncing this branch with current `main`, `matryoshka` also showed why the cached API should not simply fail without Embree: it precomputes an intersector and reuses it throughout its optimization. Making the precompute object backend-agnostic preserves that public operation and avoids rebuilding a portable tree for every query.

Default builds are unchanged and continue to use Embree. Only builds that explicitly disable it select the portable backend, with the expected performance difference but the same public result semantics.

## Validation

- Built the native extension on macOS ARM64 with `LIBIGL_EMBREE=OFF`.
- Verified the module reports `_has_embree is False`.
- Verified ordinary and cached ray queries match the explicit portable path.
- Verified a no-Embree `matryoshka` scale-only case succeeds.
- Ran the focused no-Embree suite: 9 tests passed; 2 Embree-only performance tests were skipped.
- The full Linux and macOS CI suites passed on the merged substantive head before the final portable-cache commit.
